### PR TITLE
docs: consolidate documentation and add doc-sync Cursor rule

### DIFF
--- a/.cursor/rules/docs-with-code-changes.mdc
+++ b/.cursor/rules/docs-with-code-changes.mdc
@@ -1,0 +1,33 @@
+---
+description: Update documentation whenever production code or dependencies change
+alwaysApply: true
+---
+
+# Keep documentation in sync with code
+
+When you change **implementation** (not typo-only or purely mechanical refactors with no behavior change), update the **authoritative** docs in the same effort so they stay accurate. Do not leave design docs, READMEs, or rules describing behavior that no longer exists.
+
+## Where to edit (use the doc map)
+
+Use **[SYSTEM_DESIGN.md](SYSTEM_DESIGN.md#documentation-map)** and the root **[README.md](README.md#documentation)** “Documentation” table. Typical mapping:
+
+| Code / topic | Update these docs (as applicable) |
+| --- | --- |
+| `pdf_wizard/main.go`, `app.go`, menu, config path, models | [pdf_wizard/DESIGN.md](pdf_wizard/DESIGN.md) |
+| `pdf_wizard/services/*`, merge/split/rotate/watermark behavior | [pdf_wizard/services/DESIGN.md](pdf_wizard/services/DESIGN.md) and [SYSTEM_DESIGN.md](SYSTEM_DESIGN.md) (architecture, PDF sections, error handling) |
+| `frontend/src/components/*`, Settings UX | [pdf_wizard/frontend/src/components/DESIGN.md](pdf_wizard/frontend/src/components/DESIGN.md) |
+| `frontend/src/utils/i18n/*`, locales, `useI18n` | [pdf_wizard/frontend/src/utils/i18n/DESIGN.md](pdf_wizard/frontend/src/utils/i18n/DESIGN.md) |
+| Drag/drop, tab routing, cross-cutting UI architecture | [SYSTEM_DESIGN.md](SYSTEM_DESIGN.md) |
+| `wails build`, `build-dist.sh`, DMG/ZIP/installers | [pdf_wizard/DISTRIBUTION.md](pdf_wizard/DISTRIBUTION.md) |
+| User-facing install, prerequisites, quick start | [README.md](README.md) |
+| `go.mod` / `package.json` versions, major stack choices | [README.md](README.md) prerequisites or features, and [SYSTEM_DESIGN.md](SYSTEM_DESIGN.md) technology stack |
+
+If a change spans layers, touch every doc that currently states the old behavior—**one source of truth per topic**; do not copy long paragraphs into multiple files. Prefer a short update plus a link to the canonical section.
+
+## Checklist before finishing a code change
+
+1. Did any public API, CLI, config shape, or user-visible behavior change? If yes, docs must reflect it.
+2. Did dependencies or minimum tool versions change? Update README / SYSTEM_DESIGN version lines.
+3. Did tests or build steps change? Update [SYSTEM_DESIGN.md § Testing](SYSTEM_DESIGN.md#testing), [pdf_wizard/README.md](pdf_wizard/README.md), or [pdf_wizard/frontend/e2e/README.md](pdf_wizard/frontend/e2e/README.md) as appropriate.
+
+When unsure which file is canonical, start from the **Documentation map** in SYSTEM_DESIGN.md.

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Logs
 *.log
 
+# Wails / Go build output
+pdf_wizard/build/
+
 # Node.js / Frontend
 pdf_wizard/frontend/node_modules
 pdf_wizard/frontend/dist

--- a/README.md
+++ b/README.md
@@ -118,7 +118,21 @@ Pre-built installers are available in the [`pdf_wizard/dist/`](https://github.co
 
 - **Go 1.24.0** (specified in `go.mod`)
 - **Node.js 22.21.1** (required by the project)
-- **Wails CLI v2.11.0** (matches `github.com/wailsapp/wails/v2 v2.11.0` in `go.mod`)
+- **Wails CLI v2.12.0** (matches `github.com/wailsapp/wails/v2 v2.12.0` in `pdf_wizard/go.mod`)
+
+## Documentation
+
+Long-form material lives in dedicated files so it is not copied in multiple places:
+
+| Topic | Document |
+| --- | --- |
+| Architecture, UI patterns, watermark spec | [SYSTEM_DESIGN.md](SYSTEM_DESIGN.md) (includes a **documentation map**) |
+| Release packaging (DMG, ZIP, `build-dist.sh`, NSIS) | [pdf_wizard/DISTRIBUTION.md](pdf_wizard/DISTRIBUTION.md) |
+| `main.go`, `app.go`, menu, config file, models | [pdf_wizard/DESIGN.md](pdf_wizard/DESIGN.md) |
+| Tab components and Settings UI | [pdf_wizard/frontend/src/components/DESIGN.md](pdf_wizard/frontend/src/components/DESIGN.md) |
+| Go services (merge, split, rotate, watermark) | [pdf_wizard/services/DESIGN.md](pdf_wizard/services/DESIGN.md) |
+| i18n files, `useI18n`, adding a language | [pdf_wizard/frontend/src/utils/i18n/DESIGN.md](pdf_wizard/frontend/src/utils/i18n/DESIGN.md) |
+| Daily commands from `pdf_wizard/` | [pdf_wizard/README.md](pdf_wizard/README.md) |
 
 ## Quick Start
 
@@ -161,286 +175,32 @@ For development instructions, see [pdf_wizard/README.md](pdf_wizard/README.md).
 
 ## Building
 
-### Build Executables
-
-Build platform-specific executables:
-
-```bash
-cd pdf_wizard
-wails build
-```
-
-The output will be generated in the `pdf_wizard/build/bin` directory.
-
-**Build for macOS Distribution:**
-
-To create a universal binary that works on both Intel and Apple Silicon Macs:
-
-```bash
-cd pdf_wizard
-wails build -platform darwin/universal
-```
-
-For distribution to other Mac machines, see [Distribution Guide](pdf_wizard/DISTRIBUTION.md).
-
-**Build for Windows Distribution:**
-
-To create a Windows executable:
-
-```bash
-cd pdf_wizard
-wails build
-```
-
-This will create in `build/bin`:
-
-- `PDF Wizard.exe` - Standalone executable
-- `PDF Wizard Installer.exe` - NSIS installer (if NSIS is installed)
-
-For distribution packages in the `dist` directory, use the build script:
-
-```bash
-cd pdf_wizard
-./build-dist.sh
-```
-
-This will create in `dist`:
-
-- `pdf_wizard-windows.exe` - Standalone executable (matches macOS naming convention)
-- `pdf_wizard-windows-installer.exe` - NSIS installer (only if NSIS is installed on the build machine)
-- `pdf_wizard-windows-portable.zip` - ZIP archive containing the executable
-
-> **Note**: To create the NSIS installer, you need to install NSIS first:
->
-> - Download from: https://nsis.sourceforge.io/Download
-> - Or install via Chocolatey (as Administrator): `choco install nsis`
-> - After installing NSIS, rebuild the project to generate the installer
-
-**Quick Distribution Build:**
-
-Use the automated build script (cross-platform):
-
-**On macOS/Linux:**
-
-```bash
-cd pdf_wizard
-./build-dist.sh
-```
-
-**On Windows (PowerShell):**
-
-```powershell
-cd pdf_wizard
-.\build-dist.ps1
-```
-
-**On Windows (Git Bash/WSL):**
-
-```bash
-cd pdf_wizard
-./build-dist.sh
-```
-
-The script automatically detects your operating system and creates:
-
-- **macOS**: DMG installer and ZIP archive
-- **Windows**: NSIS installer (if NSIS is installed) and portable ZIP archive
-
-All distribution files are created in the `pdf_wizard/dist` directory.
+From `pdf_wizard/`, run `wails build` (output under `pdf_wizard/build/bin/`). Universal macOS builds, `build-dist.sh` / `build-dist.ps1`, DMG/ZIP/Windows artifacts, and NSIS notes are documented only in **[pdf_wizard/DISTRIBUTION.md](pdf_wizard/DISTRIBUTION.md)**.
 
 ## Testing
 
-PDF Wizard includes both backend integration tests and frontend E2E tests.
-
-### Backend Integration Tests
-
-Run the Go integration tests locally:
-
 ```bash
-cd pdf_wizard
-go test -v ./...
+cd pdf_wizard && go test -v ./...
 ```
 
-This will run all tests with verbose output.
-
-**Test Coverage:**
-
-To see test coverage:
-
 ```bash
-cd pdf_wizard
-go test -v -coverprofile=coverage.out ./...
-go tool cover -func=coverage.out
+cd pdf_wizard/frontend && npm run test:e2e
 ```
 
-To view an HTML coverage report:
-
-```bash
-go tool cover -html=coverage.out
-```
-
-**Run Specific Tests:**
-
-Run a specific test function:
-
-```bash
-cd pdf_wizard
-go test -v -run TestGetFileMetadata
-```
-
-Run language management tests:
-
-```bash
-cd pdf_wizard
-go test -v -run "TestGetLanguage|TestSetLanguage"
-```
-
-Run tests with race detection:
-
-```bash
-cd pdf_wizard
-go test -v -race ./...
-```
-
-**Backend Test Coverage:**
-
-The backend test suite includes:
-
-- PDF file operations (merge, split, rotate)
-- File metadata retrieval
-- Page count operations
-- Error handling and validation
-- **Language management**:
-  - Language preference storage and retrieval
-  - Config file handling
-  - Default language fallback
-  - Invalid config handling
-
-### Frontend E2E Tests
-
-The frontend uses Playwright for end-to-end UI testing. These tests verify the application UI, user interactions, and component behavior.
-
-**Running Tests Locally:**
-
-```bash
-cd pdf_wizard/frontend
-npm run test:e2e
-```
-
-For detailed E2E testing instructions, test structure, configuration, and CI/CD setup, see the [E2E Testing README](pdf_wizard/frontend/e2e/README.md).
+Coverage reports, filtering tests by name, and Playwright/CI details: **[pdf_wizard/frontend/e2e/README.md](pdf_wizard/frontend/e2e/README.md)** and **[SYSTEM_DESIGN.md § Testing](SYSTEM_DESIGN.md#testing)**.
 
 ## Features
 
-### Watermark PDFs
+- **Watermark PDFs** (language-aware fonts, positions, opacity): [SYSTEM_DESIGN.md — Watermark PDF Tab](SYSTEM_DESIGN.md#watermark-pdf-tab).
+- **Internationalization** (12 languages, `useI18n`, adding a locale): [pdf_wizard/frontend/src/utils/i18n/DESIGN.md](pdf_wizard/frontend/src/utils/i18n/DESIGN.md).
 
-The watermark feature includes intelligent font selection based on your application language. Font options automatically filter to show only fonts appropriate for your selected language (Chinese, Japanese, Korean, Hindi, and standard fonts for other languages), with automatic default selection and localized font names.
+## Technology stack
 
-For detailed information about language-specific fonts and watermark customization options, see [SYSTEM_DESIGN.md](SYSTEM_DESIGN.md#watermark-pdf-tab).
+Stack versions and dependencies (Go modules, React, MUI, pdfcpu, Playwright, etc.) are listed in **[SYSTEM_DESIGN.md § Technology stack](SYSTEM_DESIGN.md#technology-stack)** and **[§ Technical considerations](SYSTEM_DESIGN.md#technical-considerations)**.
 
-### Internationalization (i18n)
+## Repository layout
 
-PDF Wizard supports multiple languages with an easy-to-use translation system:
-
-- **Supported Languages**:
-  - English (en)
-  - Chinese Simplified (zh)
-  - Chinese Traditional (zh-TW)
-  - Arabic (ar)
-  - French (fr)
-  - Japanese (ja)
-  - Hindi (hi)
-  - Spanish (es)
-  - Portuguese (pt)
-  - Russian (ru)
-  - Korean (ko)
-  - German (de)
-- **Language Selection**: Accessible via the Settings menu in the application menu bar
-- **Language Persistence**: Your language preference is saved and persists across application restarts
-- **Modular Structure**: Translations are organized in separate language files for easy maintenance and extension
-- **Native Language Names**: Language options are displayed in their native script for better user experience
-
-**Adding New Languages:**
-
-To add a new language:
-
-1. Create a new file in `pdf_wizard/frontend/src/utils/i18n/` (e.g., `de.ts` for German)
-2. Export a `Translations` object with all required translation keys (see `types.ts` for the interface)
-3. Import the new language file in `i18n/index.ts`
-4. Add the language to the `translations` record in `i18n/index.ts`
-5. Update the `Language` type in `i18n/types.ts` to include the new language code
-6. Add the language to the `getNativeLanguageName` function in `i18n/index.ts`
-7. Add the language option to the Settings dialog component (`SettingsDialog.tsx`)
-8. Update the validation arrays in `App.tsx` and `SettingsDialog.tsx` to include the new language code
-9. Update the backend validation in `app.go` (`GetLanguage()` and `SetLanguage()` functions) to include the new language code
-
-## Technology Stack
-
-### Backend
-
-- **Go 1.24.0**: High-performance backend services
-- **Wails v2.11.0**: Desktop application framework
-- **pdfcpu**: PDF manipulation library for merging, splitting, and rotating
-- **JSON Config**: Language preference stored in user config directory
-
-### Frontend
-
-- **React 18**: Modern UI library with hooks
-- **TypeScript**: Type-safe development
-- **Material-UI (MUI) v7**: Component library for modern UI
-- **@dnd-kit**: Modern drag-and-drop library (replaced deprecated react-beautiful-dnd)
-- **Vite**: Fast build tool and dev server
-- **Custom i18n System**: Internationalization support with modular language files
-  - Language files: `i18n/en.ts`, `i18n/zh.ts`, `i18n/zh-TW.ts`, `i18n/ar.ts`, `i18n/fr.ts`, `i18n/ja.ts`, `i18n/hi.ts`, `i18n/es.ts`, `i18n/pt.ts`, `i18n/ru.ts`, `i18n/ko.ts`, `i18n/de.ts`
-  - Type definitions: `i18n/types.ts`
-  - Main logic: `i18n/index.ts` (includes `getNativeLanguageName` helper)
-
-### Testing
-
-- **Playwright**: End-to-end testing framework
-- **Go Testing**: Unit and integration tests
-
-## Project Structure
-
-```
-PDF_Wizard/
-├── pdf_wizard/          # Main Wails application
-│   ├── frontend/        # React/TypeScript frontend
-│   │   ├── e2e/         # Playwright E2E tests
-│   │   ├── src/         # React source code
-│   │   │   ├── components/    # React components
-│   │   │   │   ├── MergeTab.tsx
-│   │   │   │   ├── SplitTab.tsx
-│   │   │   │   ├── RotateTab.tsx
-│   │   │   │   └── SettingsDialog.tsx
-│   │   │   ├── utils/         # Utility functions
-│   │   │   │   ├── i18n/      # Internationalization
-│   │   │   │   │   ├── index.ts    # Main i18n logic
-│   │   │   │   │   ├── types.ts    # TypeScript types
-│   │   │   │   │   ├── en.ts       # English translations
-│   │   │   │   │   ├── zh.ts       # Chinese Simplified translations
-│   │   │   │   │   ├── zh-TW.ts    # Chinese Traditional translations
-│   │   │   │   │   ├── ar.ts       # Arabic translations
-│   │   │   │   │   ├── fr.ts       # French translations
-│   │   │   │   │   ├── ja.ts       # Japanese translations
-│   │   │   │   │   ├── hi.ts       # Hindi translations
-│   │   │   │   │   ├── es.ts       # Spanish translations
-│   │   │   │   │   ├── pt.ts       # Portuguese translations
-│   │   │   │   │   ├── ru.ts       # Russian translations
-│   │   │   │   │   ├── ko.ts       # Korean translations
-│   │   │   │   │   └── de.ts       # German translations
-│   │   │   │   └── formatters.ts
-│   │   │   └── App.tsx        # Main application component
-│   │   └── dist/        # Built frontend assets
-│   ├── services/        # Go service layer
-│   ├── models/          # Data models
-│   ├── app.go           # Go application entry (includes language management)
-│   └── main.go          # Wails main file
-├── assets/              # Application assets
-│   └── img/             # Application images and logos
-│       ├── app_logo_raw.png  # Source logo (high resolution)
-│       └── app_logo.png      # Application logo (128x128)
-└── .github/workflows/   # GitHub Actions CI/CD workflows
-```
+High-level tree and the role of each major folder: **[SYSTEM_DESIGN.md § Project Structure](SYSTEM_DESIGN.md#project-structure)**.
 
 ## Configuration
 
@@ -460,20 +220,7 @@ The config file is automatically created when you change the language. You can a
 }
 ```
 
-Valid values are:
-
-- `"en"` - English
-- `"zh"` - Chinese Simplified
-- `"zh-TW"` - Chinese Traditional
-- `"ar"` - Arabic
-- `"fr"` - French
-- `"ja"` - Japanese
-- `"hi"` - Hindi
-- `"es"` - Spanish
-- `"pt"` - Portuguese
-- `"ru"` - Russian
-- `"ko"` - Korean
-- `"de"` - German
+Valid `"language"` values are exactly the codes in **`pdf_wizard/frontend/src/utils/i18n/constants.ts`** (`SUPPORTED_LANGUAGES`), which must match **`validLanguages`** in **`pdf_wizard/app.go`**. See [pdf_wizard/DESIGN.md](pdf_wizard/DESIGN.md) for path resolution and error handling.
 
 ## Troubleshooting
 

--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -4,6 +4,21 @@
 
 PDF Wizard is a cross-platform desktop application built with Wails v2 that provides PDF manipulation capabilities, including merging, splitting, rotating, and watermarking PDF files. The application uses a Go backend for file operations and a React/TypeScript frontend with Material-UI for the user interface.
 
+## Documentation map
+
+Avoid duplicating long procedures across files. Use this table to find the **single** place each topic is maintained:
+
+| Topic | Canonical document |
+| --- | --- |
+| Product overview, downloads, install, troubleshooting | [README.md](README.md) |
+| Release builds (DMG, ZIP, `build-dist.sh`) | [pdf_wizard/DISTRIBUTION.md](pdf_wizard/DISTRIBUTION.md) |
+| Commands from `pdf_wizard/` (`wails dev`, quick test entry points) | [pdf_wizard/README.md](pdf_wizard/README.md) |
+| Native menu, `app.go`, config file, models, Wails `options.App` | [pdf_wizard/DESIGN.md](pdf_wizard/DESIGN.md) |
+| Tab components and Settings dialog UI | [pdf_wizard/frontend/src/components/DESIGN.md](pdf_wizard/frontend/src/components/DESIGN.md) |
+| File/PDF services (`FileService`, `PDFService`) | [pdf_wizard/services/DESIGN.md](pdf_wizard/services/DESIGN.md) |
+| i18n layout, `useI18n`, adding a language | [pdf_wizard/frontend/src/utils/i18n/DESIGN.md](pdf_wizard/frontend/src/utils/i18n/DESIGN.md) |
+| **This file** | End-to-end architecture, UI patterns, watermark spec, cross-cutting technical notes |
+
 **Supported Platforms:**
 
 - macOS (Intel and Apple Silicon - universal binary)
@@ -13,10 +28,10 @@ PDF Wizard is a cross-platform desktop application built with Wails v2 that prov
 
 ### Technology Stack
 
-- **Backend**: Go 1.24.0 with Wails v2.11.0
+- **Backend**: Go 1.24.0 with Wails v2.12.0
 - **Frontend**: React 18+ with TypeScript, Material-UI (MUI) v7
 - **PDF Processing**: `github.com/pdfcpu/pdfcpu v0.11.1` - Native Go PDF library
-- **Build Tool**: Wails CLI v2.11.0
+- **Build Tool**: Wails CLI v2.12.0 (align with `github.com/wailsapp/wails/v2 v2.12.0` in `go.mod`)
 - **UI Framework**: Material-UI
 - **Drag and Drop**: `@dnd-kit/core`, `@dnd-kit/sortable`, and `@dnd-kit/utilities` for file reordering (replaced deprecated react-beautiful-dnd)
 - **Internationalization**: Custom i18n system supporting 12 languages (English, Chinese Simplified, Chinese Traditional, Arabic, French, Japanese, Hindi, Spanish, Portuguese, Russian, Korean, German)
@@ -39,7 +54,9 @@ pdf_wizard/
 │   └── types.go           # PDFMetadata, SplitDefinition, RotateDefinition, WatermarkDefinition
 ├── frontend/
 │   ├── src/
+│   │   ├── main.tsx       # React entry; wraps App in I18nProvider
 │   │   ├── App.tsx        # Main application component with tab navigation
+│   │   ├── hooks/         # Shared hooks (PDF drop, errors, processing state, output directory)
 │   │   ├── components/    # React components
 │   │   │   ├── MergeTab.tsx
 │   │   │   ├── SplitTab.tsx
@@ -49,9 +66,13 @@ pdf_wizard/
 │   │   │   └── DESIGN.md  # Components design
 │   │   ├── types/         # TypeScript type definitions
 │   │   └── utils/         # Utility functions
+│   │       ├── constants.ts # MAIN_TAB_IDS / MainTabId; shared UI constants
 │   │       ├── formatters.ts
 │   │       └── i18n/       # Internationalization utilities
-│   │           ├── index.ts
+│   │           ├── index.ts           # Barrel exports (useI18n, types, getNativeLanguageName)
+│   │           ├── I18nProvider.tsx   # React context; current language and t()
+│   │           ├── catalog.ts        # Merged translation map and lookup helpers
+│   │           ├── constants.ts      # SUPPORTED_LANGUAGES, isValidLanguage
 │   │           ├── types.ts
 │   │           ├── en.ts       # English translations
 │   │           ├── zh.ts       # Chinese Simplified translations
@@ -98,7 +119,7 @@ The application features a tabbed interface with four main tabs:
 Drag and drop file handling is implemented at the App level to work anywhere on the window:
 
 - A single `OnFileDrop` handler is registered at the App component level with `useDropTarget=false` to work anywhere on the window
-- The handler routes dropped files to the appropriate tab based on the currently active tab (using refs to track current tab)
+- The handler routes dropped files using **stable tab ids** (`merge`, `split`, `rotate`, `watermark`) defined by `MAIN_TAB_IDS` in `utils/constants.ts`. `activeTabIdRef` holds the current tab id; each tab registers a handler in `dropHandlersRef`, a `Partial<Record<MainTabId, ...>>` keyed by that id (not by numeric tab index)
 - Each tab component registers its own drop handler via a callback prop
 - Cross-platform compatibility:
   - **Windows**: `DisableWebViewDrop: true` in Wails config prevents WebView2 from intercepting drag-and-drop events
@@ -108,114 +129,11 @@ Drag and drop file handling is implemented at the App level to work anywhere on 
 
 ### Internationalization (i18n)
 
-The application supports multiple languages through a custom internationalization system:
+The application supports **12 languages** through a custom i18n stack: per-language modules merged in `catalog.ts`, wrapped by `I18nProvider` in `main.tsx`, and consumed via `useI18n()` (`t`, `setLanguage`). Locale codes, `SUPPORTED_LANGUAGES`, and how to add a language are maintained in **[pdf_wizard/frontend/src/utils/i18n/DESIGN.md](pdf_wizard/frontend/src/utils/i18n/DESIGN.md)**.
 
-- **Supported Languages**: 12 languages total
-  - English (en)
-  - Chinese Simplified (zh)
-  - Chinese Traditional (zh-TW)
-  - Arabic (ar)
-  - French (fr)
-  - Japanese (ja)
-  - Hindi (hi)
-  - Spanish (es)
-  - Portuguese (pt)
-  - Russian (ru)
-  - Korean (ko)
-  - German (de)
-- **Language Selection**: Available through the Settings dialog (accessible via menu bar)
-- **Language Persistence**: User's language preference is saved to a configuration file in the user's config directory
-- **Translation System**: All UI text uses translation keys accessed via the `t()` function from `utils/i18n`
-- **Dynamic Updates**: UI updates immediately when language is changed
-- **Default Language**: English (en) is the default if no preference is set
-- **Native Language Names**: Language options are displayed in their native script for better user experience
+### Native menu, window options, config file, and Settings
 
-For detailed i18n implementation, see [`frontend/src/utils/i18n/DESIGN.md`](frontend/src/utils/i18n/DESIGN.md).
-
-#### Settings Dialog
-
-- Accessible via the "Settings" menu item in the application menu bar
-- Allows users to select from 12 supported languages
-- Language options are displayed in their native script (e.g., "简体中文", "繁體中文", "한국어", "Deutsch")
-- Changes are saved immediately and persist across application restarts
-- Uses Material-UI Dialog component for consistent UI
-- Language preference is loaded on application startup
-- Frontend listens for "show-settings" event from backend to open dialog
-
-#### Menu Configuration
-
-The application menu is configured in `main.go`:
-
-```go
-// Create menu with AppMenu (includes "About PDF Wizard" automatically)
-appMenu := menu.NewMenu()
-appMenu.Append(menu.AppMenu())
-
-// Add Settings menu item
-settingsSubMenu := menu.NewMenu()
-settingsSubMenu.Append(menu.Text("Settings", nil, func(_ *menu.CallbackData) {
-    app.EmitSettingsEvent()
-}))
-appMenu.Append(menu.SubMenu("Settings", settingsSubMenu))
-
-appMenu.Append(menu.EditMenu())
-appMenu.Append(menu.WindowMenu())
-```
-
-- The `menu.AppMenu()` function automatically includes "About PDF Wizard" and other standard macOS app menu items
-- Settings is added as a separate menu item (not inside AppMenu)
-- Settings menu item triggers `EmitSettingsEvent()` which emits a "show-settings" event
-- Frontend listens for this event using `EventsOn('show-settings', ...)` and opens the Settings dialog
-- Menu is native on macOS (appears in the menu bar at the top of the screen)
-
-#### Application Configuration
-
-The application is configured with the following options in `main.go`:
-
-```go
-&options.App{
-    Title:     "PDF Wizard",
-    Width:     1024,
-    Height:    900,
-    MinWidth:  800,
-    MinHeight: 600,
-    BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
-    DragAndDrop: &options.DragAndDrop{
-        EnableFileDrop:     true,
-        DisableWebViewDrop: true, // Prevents WebView interference on Windows and macOS
-    },
-    Mac: &mac.Options{
-        About: &mac.AboutInfo{
-            Title:   "PDF Wizard",
-            Message: "A modern PDF toolkit built with Wails v2\n\nAuthor: Hanxiong Shi\nVersion 1.0.0\nCopyright © 2026",
-        },
-    },
-}
-```
-
-- **Window Size**: 1024x900 pixels (minimum 800x600)
-- **Background Color**: Dark theme (RGB: 27, 38, 54)
-- **Drag and Drop**: Enabled with `DisableWebViewDrop: true` for cross-platform compatibility
-- **macOS About Dialog**: Custom About information with author, version, and copyright
-
-For detailed menu and application configuration, see [`DESIGN.md`](DESIGN.md).
-
-#### Configuration File
-
-Language preference is stored in a JSON configuration file:
-
-- **Location**: `<UserConfigDir>/PDF Wizard/pdf_wizard_config.json`
-  - On macOS: `~/Library/Application Support/PDF Wizard/pdf_wizard_config.json`
-  - On Windows: `%AppData%\PDF Wizard\pdf_wizard_config.json`
-  - On Linux: `~/.config/PDF Wizard/pdf_wizard_config.json`
-- **Structure**:
-  ```json
-  {
-    "language": "en"
-  }
-  ```
-- **Default**: If the file doesn't exist or is invalid, the default language is "en" (English)
-- **Persistence**: The config directory is created automatically if it doesn't exist
+Menu construction, Wails `options.App`, the JSON config path, and `GetLanguage` / `SetLanguage` / `EmitSettingsEvent` are documented in **[pdf_wizard/DESIGN.md](pdf_wizard/DESIGN.md)**. Settings dialog layout is in **[pdf_wizard/frontend/src/components/DESIGN.md](pdf_wizard/frontend/src/components/DESIGN.md)**.
 
 ## Component Design
 
@@ -228,7 +146,7 @@ The application consists of four main tab components:
 
 Each component handles its own state, file selection, validation, and processing.
 
-For detailed component design and implementation, see [`frontend/src/components/DESIGN.md`](frontend/src/components/DESIGN.md).
+For detailed component design and implementation, see [pdf_wizard/frontend/src/components/DESIGN.md](pdf_wizard/frontend/src/components/DESIGN.md).
 
 ## Backend Services
 
@@ -250,8 +168,8 @@ The backend uses a service-based architecture with clear separation of concerns:
 
 #### MergePDFs
 
-- **Pre-validation**: Validates each PDF can be read using `api.ReadContextFile()` before merging to identify problematic files
-- **Font encoding handling**: Provides specific error messages for font encoding issues (e.g., NULL encoding), suggesting PDF repair
+- **Merge-first, then diagnose**: Attempts `api.MergeCreateFile()` first (pdfcpu reads inputs as part of the merge). If merge fails, `mergeDiagnoseInputs()` runs `api.ReadContextFile()` on each input in order to report which file fails and why (e.g., font encoding / NULL encoding), suggesting PDF repair where applicable
+- **Font encoding handling**: Diagnosis path surfaces encoding-related read errors with filename and index
 - **Output file handling**: Removes existing output file before creating new one to avoid pdfcpu overwrite issues
 - **Error messages**: Includes filename and file index in error messages for better debugging
 
@@ -269,7 +187,7 @@ The backend uses a service-based architecture with clear separation of concerns:
 - **Opacity simulation**: Since pdfcpu doesn't support alpha channel, opacity is simulated by blending color with white
 - **Helper functions**: Includes specialized functions for page range parsing, position conversion, color parsing, and opacity adjustment
 
-For detailed service implementation, see [`services/DESIGN.md`](services/DESIGN.md).
+For detailed service implementation, see [pdf_wizard/services/DESIGN.md](pdf_wizard/services/DESIGN.md).
 
 ## Application-Level Design
 
@@ -281,7 +199,7 @@ The application-level design covers:
 - Event communication between menu and frontend
 - Data models (`models/types.go`)
 
-For detailed application-level design, see [`DESIGN.md`](DESIGN.md).
+For detailed application-level design, see [pdf_wizard/DESIGN.md](pdf_wizard/DESIGN.md).
 
 ## Technical Considerations
 
@@ -305,13 +223,13 @@ For detailed application-level design, see [`DESIGN.md`](DESIGN.md).
 - TypeScript
 - Wails runtime bindings
 - `@dnd-kit/core`, `@dnd-kit/sortable`, and `@dnd-kit/utilities` - For drag-and-drop file reordering (replaced deprecated react-beautiful-dnd)
-- Custom i18n system (`utils/i18n/`) - For internationalization (modular structure with separate translation files for 12 languages)
+- Custom i18n system (`utils/i18n/`) - For internationalization (per-language modules, `catalog.ts` merge, React `I18nProvider` / `useI18n` for 12 languages)
 
 ### Error Handling
 
 - Validate PDF files before processing (file existence, PDF format, readability)
 - Handle file access errors gracefully with descriptive messages
-- **Font encoding validation**: Merge operation validates each PDF can be read before merging, with specific error messages for font encoding issues (e.g., NULL encoding)
+- **Font encoding / read errors on merge**: After a failed merge, per-input `ReadContextFile` diagnosis yields specific messages (e.g., NULL encoding) tied to filename and index
 - **Page range validation**: All operations validate page ranges against PDF page count
 - **Output file handling**: Existing output files are removed before creating new ones to avoid pdfcpu overwrite issues
 - **Temporary file management**: Rotate and watermark operations use temporary files to avoid in-place modification issues, with automatic cleanup
@@ -548,27 +466,7 @@ func (a *App) ApplyWatermark(
 
 ### Internationalization
 
-All translation keys have been implemented and are available in all 12 supported languages:
-
-- `watermarkTab` - "Watermark PDF"
-- `selectPDFFileWatermark` - "Select PDF File"
-- `watermarkText` - "Watermark Text"
-- `fontSize` - "Font Size"
-- `fontColor` - "Font Color"
-- `opacity` - "Opacity"
-- `rotation` - "Rotation"
-- `position` - "Position"
-- `fontFamily` - "Font Family"
-- `pageRange` - "Page Range"
-- `allPages` - "All Pages"
-- `specificPages` - "Specific Pages"
-- `pages` - "Pages"
-- `applyWatermark` - "Apply Watermark"
-- `applying` - "Applying watermark..."
-- `watermarkAppliedSuccessfully` - "Watermark applied successfully! Output:"
-- `watermarkFailed` - "Watermark failed:"
-- Position options (center, top-left, top-center, etc.)
-- **Font name translations**: All font names are translated and displayed in the user's selected language (e.g., "SimSun (宋体)" in English, "宋体" in Chinese)
+Watermark strings use the same **`useI18n()`** / `Translations` pipeline as the rest of the app; keys live in **`frontend/src/utils/i18n/types.ts`** and each `*.ts` locale file. Adding or renaming keys is covered in [pdf_wizard/frontend/src/utils/i18n/DESIGN.md](pdf_wizard/frontend/src/utils/i18n/DESIGN.md).
 
 #### Language-Specific Font Selection
 
@@ -611,33 +509,17 @@ The watermark feature includes **intelligent font selection** based on the appli
 
 ## Testing
 
-PDF Wizard includes comprehensive testing at multiple levels:
-
-### Backend Integration Tests
-
-- **Location**: Go test files alongside service implementations
-- **Coverage**: PDF operations (merge, split, rotate, watermark), file metadata, page count, error handling, language management
-- **Run**: `go test -v ./...` from the `pdf_wizard` directory
-- **Test PDF Generation**: Backend utilities (`createTestPDF`, `createMultiPageTestPDF`) generate minimal valid PDF files for testing
-
-### Frontend E2E Tests
-
-- **Framework**: Playwright
-- **Test Files**: Organized by functionality (app, components, tabs, i18n)
-- **Test PDF**: Uses `e2e/helpers/test.pdf` for testing PDF operations
-- **Mocking**: Wails runtime and Go bindings are mocked for UI-only testing
-- **CI/CD**: GitHub Actions workflow runs tests in parallel using a matrix strategy
-
-For detailed E2E testing information, including test structure, configuration, and CI/CD setup, see [`frontend/e2e/README.md`](frontend/e2e/README.md).
+- **Backend** (from `pdf_wizard`): `go test -v ./...`. Filter: `go test -v -run TestName ./...`. Coverage: `go test -v -coverprofile=coverage.out ./...` then `go tool cover -func=coverage.out` or `go tool cover -html=coverage.out`.
+- **Frontend E2E** (Playwright): `cd frontend && npm run test:e2e`. Structure, fixtures, and CI: **[pdf_wizard/frontend/e2e/README.md](pdf_wizard/frontend/e2e/README.md)**.
 
 ## Design Documentation
 
-For detailed design information, refer to the following documents:
+Use the [Documentation map](#documentation-map) at the top of this file. Quick links:
 
-- **[Application Design](DESIGN.md)** - Main entry point, app wrapper, menu configuration, models, and configuration management
-- **[Components Design](frontend/src/components/DESIGN.md)** - Detailed design for MergeTab, SplitTab, RotateTab, WatermarkTab, and SettingsDialog components
-- **[Services Design](services/DESIGN.md)** - Backend service layer architecture and implementation (FileService, PDFService)
-- **[i18n Design](frontend/src/utils/i18n/DESIGN.md)** - Internationalization system architecture and usage
+- [pdf_wizard/DESIGN.md](pdf_wizard/DESIGN.md) — main entry, menu, config, models
+- [pdf_wizard/frontend/src/components/DESIGN.md](pdf_wizard/frontend/src/components/DESIGN.md) — tab components
+- [pdf_wizard/services/DESIGN.md](pdf_wizard/services/DESIGN.md) — services layer
+- [pdf_wizard/frontend/src/utils/i18n/DESIGN.md](pdf_wizard/frontend/src/utils/i18n/DESIGN.md) — i18n
 
 ## Notes
 
@@ -650,11 +532,7 @@ For detailed design information, refer to the following documents:
 - Service-based architecture for separation of concerns
 - pdfcpu library for all PDF processing operations (merge, split, rotate, watermark)
 - @dnd-kit library for drag-and-drop file reordering in Merge tab (modern replacement for deprecated react-beautiful-dnd)
-- Custom i18n system for internationalization (12 languages: English, Chinese Simplified, Chinese Traditional, Arabic, French, Japanese, Hindi, Spanish, Portuguese, Russian, Korean, German)
-  - Modular structure: `utils/i18n/` directory with separate translation files for each language
-  - Language preference stored in JSON config file: `<UserConfigDir>/PDF Wizard/pdf_wizard_config.json`
-  - Language validation in both frontend (TypeScript) and backend (Go) for consistency
-  - Native language names displayed in language selector for better UX
+- Custom i18n (12 languages): see [pdf_wizard/frontend/src/utils/i18n/DESIGN.md](pdf_wizard/frontend/src/utils/i18n/DESIGN.md); config file paths in [pdf_wizard/DESIGN.md](pdf_wizard/DESIGN.md)
 - Settings accessible via application menu bar (native menu on macOS)
   - Settings menu is separate from AppMenu (which includes "About PDF Wizard" automatically)
 - Wails Events API used for communication between menu and frontend (show-settings event)

--- a/pdf_wizard/DESIGN.md
+++ b/pdf_wizard/DESIGN.md
@@ -2,6 +2,8 @@
 
 This document describes the application-level design including the main entry point, app wrapper, menu configuration, and data models.
 
+For a map of all documentation (so topics are not repeated in multiple places), see [SYSTEM_DESIGN.md § Documentation map](../SYSTEM_DESIGN.md#documentation-map) in the repository root.
+
 ## Overview
 
 The application is structured with:
@@ -126,9 +128,9 @@ func (a *App) startup(ctx context.Context) {
 Returns the current language preference from the configuration file.
 
 - Reads from `<UserConfigDir>/PDF Wizard/pdf_wizard_config.json`
-- Returns "en" or "zh"
-- Defaults to "en" if file doesn't exist or is invalid
-- Creates config directory if it doesn't exist
+- Returns the stored code when it matches `validLanguages` in `app.go` (same set as frontend `SUPPORTED_LANGUAGES` in `frontend/src/utils/i18n/constants.ts`)
+- Defaults to `"en"` if the file is missing, invalid, or the code is not supported
+- Creates the config directory if needed
 
 **Config File Structure:**
 
@@ -148,7 +150,7 @@ Returns the current language preference from the configuration file.
 
 Saves the language preference to the configuration file.
 
-- Validates language is "en" or "zh"
+- Validates the code against `validLanguages` in `app.go`
 - Creates config directory if it doesn't exist
 - Writes JSON configuration file
 - Returns error if file operations fail
@@ -319,20 +321,7 @@ This pattern allows the native menu to trigger frontend UI updates.
 
 ## Dependencies
 
-### Go Libraries
-
-- `github.com/wailsapp/wails/v2` - Wails framework
-- `github.com/wailsapp/wails/v2/pkg/menu` - Application menu
-- `github.com/wailsapp/wails/v2/pkg/options` - Application options
-- `github.com/wailsapp/wails/v2/pkg/options/mac` - macOS-specific options
-- `github.com/wailsapp/wails/v2/pkg/runtime` - Runtime operations (events, dialogs)
-
-### Standard Library
-
-- `context` - Context for runtime operations
-- `encoding/json` - JSON encoding/decoding for config
-- `os` - File operations
-- `path/filepath` - Path manipulation
+The `App` layer uses Wails (`menu`, `options`, `runtime`, `mac`). PDF and file I/O live in `services/` and depend on **pdfcpu**; see [services/DESIGN.md](services/DESIGN.md). The full stack (Go modules, React, MUI, Playwright, etc.) is listed once in [SYSTEM_DESIGN.md § Technical Considerations](../SYSTEM_DESIGN.md#technical-considerations).
 
 ## Application Options
 
@@ -350,7 +339,8 @@ The application is configured with the following options:
     },
     BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
     DragAndDrop: &options.DragAndDrop{
-        EnableFileDrop: true,
+        EnableFileDrop:     true,
+        DisableWebViewDrop: true, // Windows WebView2 / macOS WebKit
     },
     Menu: appMenu,
     Mac: &mac.Options{
@@ -368,7 +358,7 @@ The application is configured with the following options:
 - **Title**: "PDF Wizard"
 - **Window Size**: 1024x900 (minimum 800x600)
 - **Background Color**: Dark theme (RGB: 27, 38, 54)
-- **Drag and Drop**: Enabled for file dropping anywhere on window
+- **Drag and Drop**: `EnableFileDrop` with `DisableWebViewDrop: true` so the host handles file drops (see [SYSTEM_DESIGN.md](../SYSTEM_DESIGN.md) for frontend routing)
 - **Assets**: Frontend build embedded via `//go:embed`
 - **Menu**: Custom menu with AppMenu, Settings, Edit, Window
 - **macOS About**: Custom About dialog information

--- a/pdf_wizard/DISTRIBUTION.md
+++ b/pdf_wizard/DISTRIBUTION.md
@@ -1,6 +1,6 @@
 # PDF Wizard Distribution Guide
 
-This guide explains how to build and distribute PDF Wizard for macOS and Windows platforms.
+Step-by-step packaging for maintainers (DMG, ZIP, Windows binaries, NSIS). Prerequisites and the global documentation index are in the repository **[README.md](../README.md)**; architecture notes live in **[SYSTEM_DESIGN.md](../SYSTEM_DESIGN.md)**. This file intentionally holds the **release build** detail so it is not duplicated in the root README.
 
 ## Building for Distribution
 

--- a/pdf_wizard/README.md
+++ b/pdf_wizard/README.md
@@ -1,58 +1,33 @@
-# PDF Wizard - Wails Application
+# PDF Wizard — Wails application (`pdf_wizard/`)
 
-This directory contains the main Wails application for PDF Wizard.
+This directory is the Wails project (Go + embedded React). User-facing overview, screenshots, and downloads: **[README.md](../README.md)**. Documentation map (single source per topic): **[SYSTEM_DESIGN.md § Documentation map](../SYSTEM_DESIGN.md#documentation-map)**.
 
-## About
+## Configuration
 
-PDF Wizard is a desktop application built with Wails v2 that provides PDF manipulation capabilities:
+Edit **`wails.json`** for Wails project settings. Reference: [Wails project config](https://wails.io/docs/reference/project-config).
 
-- **Merge PDFs**: Combine multiple PDF files into a single document
-- **Split PDFs**: Divide a PDF into multiple files based on page ranges
-- **Rotate PDFs**: Rotate specific page ranges in a PDF (90°, -90°, or 180°)
-- **Watermark PDFs**: Add text watermarks to PDFs with customizable font, size, color, opacity, rotation, and position. Features **language-specific fonts** that automatically adapt based on your selected language
+## Development
 
-**Key Features:**
+```bash
+cd pdf_wizard
+wails dev
+```
 
-- 🌍 **Internationalization**: Supports 12 languages (English, Chinese Simplified, Chinese Traditional, Arabic, French, Japanese, Hindi, Spanish, Portuguese, Russian, Korean, German)
-- 🎨 **Modern UI**: Built with Material-UI for a polished, responsive interface
-- 🖱️ **Drag & Drop**: Intuitive file handling with drag-and-drop support
-- ⚡ **Fast Performance**: Native Go backend ensures quick PDF processing
+Vite hot reload; optional browser devtools UI at `http://localhost:34115`.
 
-## Project Configuration
+## Build and distribution
 
-You can configure the project by editing `wails.json`. More information about the project settings can be found
-here: https://wails.io/docs/reference/project-config
+- **Binary**: `wails build` → `build/bin/`
+- **DMG / ZIP / renamed Windows artifacts**: `./build-dist.sh` or `.\build-dist.ps1` after a successful build — full procedure in **[DISTRIBUTION.md](DISTRIBUTION.md)** only.
 
-## Live Development
-
-To run in live development mode, run `wails dev` in the project directory. This will run a Vite development
-server that will provide very fast hot reload of your frontend changes. If you want to develop in a browser
-and have access to your Go methods, there is also a dev server that runs on http://localhost:34115. Connect
-to this in your browser, and you can call your Go code from devtools.
-
-## Building
-
-To build a redistributable, production mode package, use `wails build`.
-
-## Testing
-
-### Backend Tests
-
-Run Go integration tests:
+## Tests
 
 ```bash
 go test -v ./...
 ```
 
-### Frontend E2E Tests
-
-Run Playwright end-to-end tests:
-
 ```bash
-cd frontend
-npm run test:e2e
+cd frontend && npm run test:e2e
 ```
 
-For detailed E2E testing information, including test structure, test PDF usage, and CI/CD configuration, see [frontend/e2e/README.md](frontend/e2e/README.md).
-
-For more information, see the main [README.md](../README.md) in the project root.
+Playwright layout and CI: **[frontend/e2e/README.md](frontend/e2e/README.md)**. Go coverage and `-run` filters: **[SYSTEM_DESIGN.md § Testing](../SYSTEM_DESIGN.md#testing)**.

--- a/pdf_wizard/frontend/src/components/DESIGN.md
+++ b/pdf_wizard/frontend/src/components/DESIGN.md
@@ -1,16 +1,17 @@
 # PDF Wizard Components Design
 
-This document describes the design and implementation of the React components in the PDF Wizard application.
+This document describes the design and implementation of the React components in the PDF Wizard application. Documentation map: [SYSTEM_DESIGN.md](../../../../SYSTEM_DESIGN.md#documentation-map).
 
 ## Overview
 
-The application features three main tab components for PDF manipulation:
+The application features four main tab components for PDF manipulation:
 
-- **MergeTab** - Combines multiple PDF files into one
-- **SplitTab** - Divides a PDF into multiple files
-- **RotateTab** - Rotates specific page ranges in a PDF
+- **MergeTab** — combines multiple PDFs
+- **SplitTab** — divides a PDF by page ranges
+- **RotateTab** — rotates page ranges
+- **WatermarkTab** — text watermarks (see [SYSTEM_DESIGN.md — Watermark PDF Tab](../../../../SYSTEM_DESIGN.md#watermark-pdf-tab) for product-level requirements)
 
-All components use Material-UI for consistent styling and support internationalization through the `utils/i18n` system.
+Components use Material-UI. Strings use **`useI18n()`** from `utils/i18n` (see [utils/i18n/DESIGN.md](../utils/i18n/DESIGN.md)).
 
 ## Merge PDFs Tab
 

--- a/pdf_wizard/frontend/src/utils/i18n/DESIGN.md
+++ b/pdf_wizard/frontend/src/utils/i18n/DESIGN.md
@@ -1,210 +1,58 @@
-# Internationalization (i18n) Design
+# Internationalization (i18n)
 
-This document describes the internationalization system for PDF Wizard, which supports multiple languages through a modular translation system.
+**Canonical document** for PDF Wizard’s frontend translations: layout of files, runtime API, supported locales, and how to add a language. For the documentation map, see [SYSTEM_DESIGN.md](../../../../../SYSTEM_DESIGN.md#documentation-map) (repo root).
 
-## Overview
-
-The application supports multiple languages through a custom internationalization system located in `frontend/src/utils/i18n/`. The system is designed to be modular, type-safe, and easy to extend with additional languages.
-
-## Supported Languages
-
-- **English (en)** - Default language
-- **Chinese Simplified (zh)** - Full translation support
-
-## Directory Structure
+## Layout
 
 ```
-utils/i18n/
-├── index.ts      # Main export file with language management functions
-├── types.ts      # TypeScript type definitions
-├── en.ts         # English translations
-└── zh.ts         # Chinese Simplified translations
+frontend/src/utils/i18n/
+├── index.ts           # Barrel: useI18n, I18nProvider, getNativeLanguageName, types
+├── I18nProvider.tsx   # React context: language state, t(), setLanguage()
+├── catalog.ts         # Record<Language, Translations> + lookupTranslation / getTranslationsFor
+├── constants.ts       # SUPPORTED_LANGUAGES, isValidLanguage()
+├── types.ts           # Language union, Translations interface
+├── en.ts … de.ts      # One module per locale (exports Translations)
+└── DESIGN.md          # This file
 ```
 
-## Architecture
+`main.tsx` wraps the app in `<I18nProvider>` so any component can call `useI18n()`.
 
-### Translation Keys
+## Supported languages
 
-All UI text is accessed via translation keys defined in the `Translations` interface. Keys are organized by feature area:
+Codes and UI order are defined in **`constants.ts`** as `SUPPORTED_LANGUAGES`. The backend mirrors the same set in **`pdf_wizard/app.go`** (`validLanguages`). Keep those three places in sync when adding a locale: `catalog.ts`, `constants.ts`, and `app.go`.
 
-- App-level (appTitle)
-- Tabs (mergeTab, splitTab, rotateTab)
-- Settings (settings, language, english, chinese)
-- Merge Tab (selectPDFFiles, dragDropHint, etc.)
-- Split Tab (selectPDFFile, addSplit, etc.)
-- Rotate Tab (addRotate, rotation, etc.)
-- Common (modified, selectFiles, etc.)
+Current codes: `en`, `zh`, `zh-TW`, `ar`, `fr`, `ja`, `hi`, `es`, `pt`, `ru`, `ko`, `de`.
 
-### Type Definitions
+## Usage in components
 
-The `types.ts` file defines:
+```tsx
+import { useI18n } from '../utils/i18n';
 
-```typescript
-export type Language = 'en' | 'zh';
-
-export interface Translations {
-  // All translation keys with their string values
-  appTitle: string;
-  mergeTab: string;
-  // ... (see types.ts for complete list)
-}
-```
-
-### Translation Files
-
-Each language has its own translation file (`en.ts`, `zh.ts`) that exports a complete `Translations` object with all keys translated to that language.
-
-### Main Module (index.ts)
-
-The `index.ts` file provides:
-
-- **Language State Management**: Module-level variable stores current language
-- **Translation Function**: `t(key)` returns translated string for current language
-- **Language Management**: `setLanguage()`, `getLanguage()`, `getTranslations()`
-- **Type Re-exports**: Re-exports `Language` and `Translations` types for convenience
-
-## API
-
-### Functions
-
-#### `t(key: keyof Translations): string`
-
-Returns the translated string for the current language. Falls back to English if translation is missing.
-
-```typescript
-import { t } from '../utils/i18n';
-
-// Usage in components
-<Typography>{t('appTitle')}</Typography>
-<Button>{t('mergePDF')}</Button>
-```
-
-#### `setLanguage(lang: Language): void`
-
-Sets the current language. This updates the module-level state but does not trigger UI updates. Components should re-render when language changes.
-
-```typescript
-import { setLanguage } from '../utils/i18n';
-
-setLanguage('zh'); // Switch to Chinese
-```
-
-#### `getLanguage(): Language`
-
-Returns the current language setting.
-
-```typescript
-import { getLanguage } from '../utils/i18n';
-
-const currentLang = getLanguage(); // Returns 'en' or 'zh'
-```
-
-#### `getTranslations(): Translations`
-
-Returns the complete translations object for the current language.
-
-```typescript
-import { getTranslations } from '../utils/i18n';
-
-const translations = getTranslations();
-// Access all translations for current language
-```
-
-## Usage in Components
-
-All components import and use the `t()` function for UI text:
-
-```typescript
-import { t } from '../utils/i18n';
-
-export const MergeTab = () => {
-  return (
-    <Box>
-      <Button>{t('selectPDFFiles')}</Button>
-      <Typography>{t('dragDropHint')}</Typography>
-    </Box>
-  );
+export const Example = () => {
+  const { t, setLanguage } = useI18n();
+  return <Button onClick={() => setLanguage('de')}>{t('save')}</Button>;
 };
 ```
 
-## Language Loading and Persistence
+`getNativeLanguageName` (from `index.ts`) is used for the Settings language dropdown labels.
 
-### Loading on Startup
+## Persistence
 
-On application startup, `App.tsx` calls `GetLanguage()` from the backend to load the saved language preference:
+On startup, `App.tsx` calls `GetLanguage()` from the Go binding, validates with `isValidLanguage()`, then `setLanguage()`. Saving uses `SetLanguage()` then `setLanguage()`. Config file paths and JSON shape are documented in [pdf_wizard/DESIGN.md](../../../DESIGN.md).
 
-```typescript
-useEffect(() => {
-  const loadLanguage = async () => {
-    try {
-      const lang = await GetLanguage();
-      const language = (lang === 'zh' ? 'zh' : 'en') as Language;
-      setLanguage(language);
-      forceUpdate({}); // Force re-render to update UI
-    } catch (err) {
-      console.error('Failed to load language:', err);
-    }
-  };
-  loadLanguage();
-}, []);
-```
+## Adding a new language
 
-### Saving Language Preference
+1. Add **`types.ts`**: extend the `Language` type with the new code.
+2. Create **`xx.ts`**: export a complete `Translations` object (copy `en.ts` as a template).
+3. **`catalog.ts`**: import the module and add it to the `translations` record.
+4. **`index.ts`**: add the code to `getNativeLanguageName`.
+5. **`constants.ts`**: append the code to `SUPPORTED_LANGUAGES`.
+6. **`pdf_wizard/app.go`**: add the code to `validLanguages`.
 
-When the user changes the language in Settings, `SetLanguage()` is called to persist the preference:
+The Settings dialog reads `SUPPORTED_LANGUAGES`; no separate hardcoded list is required there.
 
-```typescript
-const handleSave = async () => {
-  await SetLanguage(selectedLanguage);
-  setLanguage(selectedLanguage);
-  onLanguageChange(selectedLanguage);
-  onClose();
-};
-```
+## Best practices
 
-The language preference is stored in a JSON configuration file:
-
-- **Location**: `<UserConfigDir>/PDF Wizard/pdf_wizard_config.json`
-- **Structure**: `{ "language": "en" }` or `{ "language": "zh" }`
-
-## Dynamic Updates
-
-When the language is changed:
-
-1. `SetLanguage()` is called to save the preference
-2. `setLanguage()` updates the module-level state
-3. Components re-render (via `forceUpdate()` or state change)
-4. All `t()` calls return new translations
-5. UI updates immediately with new language
-
-## Adding New Languages
-
-To add a new language:
-
-1. Add the language code to the `Language` type in `types.ts`
-2. Create a new translation file (e.g., `fr.ts` for French)
-3. Export a complete `Translations` object with all keys translated
-4. Add the new language to the `translations` record in `index.ts`
-5. Add the language option to the Settings dialog dropdown
-6. Update backend `GetLanguage()` and `SetLanguage()` to support the new code
-
-## Translation Key Organization
-
-Translation keys are organized by feature area to make it easy to find and maintain:
-
-- **App**: Application-level strings (appTitle)
-- **Tabs**: Tab labels (mergeTab, splitTab, rotateTab)
-- **Settings**: Settings dialog strings
-- **Merge Tab**: All strings used in MergeTab component
-- **Split Tab**: All strings used in SplitTab component
-- **Rotate Tab**: All strings used in RotateTab component
-- **Common**: Shared strings used across multiple components
-
-## Best Practices
-
-1. **Always use translation keys**: Never hardcode UI text strings
-2. **Use descriptive key names**: Keys should clearly indicate their purpose
-3. **Group related keys**: Keep keys for the same feature area together
-4. **Provide fallbacks**: The system falls back to English if a translation is missing
-5. **Test both languages**: Verify UI works correctly in both English and Chinese
-6. **Keep translations in sync**: When adding new features, add translations for all supported languages
+- Use `t('key')` for all user-visible strings; add the key to **`types.ts`** and every locale file.
+- Prefer English fallback: `lookupTranslation` already falls back via `catalog.ts`.
+- After adding keys, run the app in at least one non-English locale to verify layout (RTL for `ar`, CJK line heights, etc.).

--- a/pdf_wizard/services/DESIGN.md
+++ b/pdf_wizard/services/DESIGN.md
@@ -264,6 +264,8 @@ type RotateDefinition struct {
 
 ## Dependencies
 
+App-wide Go and npm dependencies are summarized in [SYSTEM_DESIGN.md § Technical considerations](../SYSTEM_DESIGN.md#technical-considerations). This section lists only what **services** import directly.
+
 ### Go Libraries
 
 - `github.com/pdfcpu/pdfcpu/pkg/api` - PDF processing library


### PR DESCRIPTION
## Summary

This updates project documentation so it matches the current codebase, reduces duplicated prose by pointing each topic at a single canonical doc, and adds a Cursor rule so future implementation changes keep docs in sync.

## Changes

- **README.md** / **SYSTEM_DESIGN.md**: refreshed versions and architecture notes; added a documentation map; trimmed duplicated sections in favor of links.
- **pdf_wizard/** DESIGN READMEs: aligned with current behavior and cross-linked.
- **`.cursor/rules/docs-with-code-changes.mdc`**: `alwaysApply: true` rule mapping code areas to authoritative docs plus a short pre-merge checklist.
- **`.gitignore`**: ignore `pdf_wizard/build/` so Wails build output is not accidentally committed.

## Notes

Build artifacts under `pdf_wizard/build/bin/pdf_wizard.app/` were unstaged and are now ignored.

Made with [Cursor](https://cursor.com)