### PR TITLE
perf: single-pass SplitPDF (fixes #57)

### DIFF
--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -173,6 +173,10 @@ The backend uses a service-based architecture with clear separation of concerns:
 - **Output file handling**: Removes existing output file before creating new one to avoid pdfcpu overwrite issues
 - **Error messages**: Includes filename and file index in error messages for better debugging
 
+#### SplitPDF
+
+- **Single-pass source read**: Opens the input once with `api.ReadValidateAndOptimize` (trim command), then for each segment runs `pdfcpu.ExtractPages` and `api.WriteContextFile`, instead of calling `api.TrimFile` per segment (which would reopen and reparse the source each time; see issue #57)
+
 #### RotatePDF
 
 - **Temporary file strategy**: Creates a temporary copy of input file because pdfcpu's `RotateFile` modifies files in place
@@ -211,6 +215,7 @@ For detailed application-level design, see [pdf_wizard/DESIGN.md](pdf_wizard/DES
 - `github.com/wailsapp/wails/v2/pkg/runtime` - File dialogs and runtime operations
 - `github.com/wailsapp/wails/v2/pkg/menu` - Application menu
 - `github.com/pdfcpu/pdfcpu/pkg/api` - PDF processing library
+- `github.com/pdfcpu/pdfcpu/pkg/pdfcpu` - Low-level helpers (e.g. `ExtractPages` after a shared read context for split)
 - `github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model` - Configuration models
 - `github.com/pdfcpu/pdfcpu/pkg/pdfcpu/color` - Color handling for watermarks
 - `github.com/pdfcpu/pdfcpu/pkg/pdfcpu/types` - PDF types and anchors

--- a/pdf_wizard/OPTIMIZATION_REPORT.md
+++ b/pdf_wizard/OPTIMIZATION_REPORT.md
@@ -1,6 +1,6 @@
 # Code optimization report
 
-Living document for performance and maintainability work in PDF Wizard. **Last updated:** 2026 (issue #62).
+Living document for performance and maintainability work in PDF Wizard. **Last updated:** 2026 (issues #57, #62).
 
 ---
 
@@ -15,7 +15,7 @@ Living document for performance and maintainability work in PDF Wizard. **Last u
 | TypeScript `any` in catch / strictness | **Partial** — e.g. `WatermarkTab` uses `unknown`; several tabs/hooks still use bare `catch (err)` |
 | Shared tab UI logic | **Partial** — `usePDFDrop`, `useOutputDirectory`, `useProcessingState`, `useErrorHandler` exist; Split/Rotate still overlap |
 | `GetPDFMetadata` / redundant `Stat` | **Open** — see backlog |
-| Split: multiple `TrimFile` passes | **Open** — see backlog |
+| Split: single read + per-segment extract | **Done** — `SplitPDF` (#57) |
 
 ---
 
@@ -25,7 +25,7 @@ Living document for performance and maintainability work in PDF Wizard. **Last u
 
 - **`services/validation.go`** — Centralized `isPDFFile`, `validatePDFFile`, `validateOutputDirectory` (replaces duplicated extension and directory checks).
 - **`services/constants.go`** — `PDFExtension`, `DefaultFilePerm`, `DefaultDirPerm`.
-- **`services/pdf_service.go`** — `MergePDFs` calls `api.MergeCreateFile` first; per-input `ReadContextFile` only runs when merge fails, to pinpoint a bad file without doubling work on successful merges (#53).
+- **`services/pdf_service.go`** — `MergePDFs` calls `api.MergeCreateFile` first; per-input `ReadContextFile` only runs when merge fails, to pinpoint a bad file without doubling work on successful merges (#53). `SplitPDF` uses one `ReadValidateAndOptimize` on the source and `ExtractPages` per segment instead of N× `TrimFile` (#57).
 
 ### Frontend
 
@@ -43,13 +43,12 @@ Living document for performance and maintainability work in PDF Wizard. **Last u
 2. **`GetPDFMetadata` / `GetPDFPageCount`** — `GetPDFMetadata` calls `os.Stat` then `GetPDFPageCount` → `validatePDFFile` stats again; reuse one stat or a single validated entry point (#54).
 3. **`parseInt` in page-range parsing** — Replace `fmt.Sscanf` in `parseInt` with `strconv.Atoi` in `pdf_service.go` (#55).
 4. **`removeIfExists`** — Prefer `os.Remove` + `errors.Is(…, fs.ErrNotExist)` over stat-then-remove (#56).
-5. **Split performance** — Investigate pdfcpu APIs to avoid N full `TrimFile` passes over the same source when many splits (#57).
-6. **Go error style** — Standardize `fmt.Errorf` wrapping and messages across services (no functional change required for consistency alone).
+5. **Go error style** — Standardize `fmt.Errorf` wrapping and messages across services (no functional change required for consistency alone).
 
 ### Low
 
-7. **React** — `React.memo` / `useCallback` where profiling shows benefit; `React.lazy` for heavy tabs if bundle size matters.
-8. **Organization** — Group related helpers; optional small `validation` subpackage if the service layer grows.
+6. **React** — `React.memo` / `useCallback` where profiling shows benefit; `React.lazy` for heavy tabs if bundle size matters.
+7. **Organization** — Group related helpers; optional small `validation` subpackage if the service layer grows.
 
 ---
 
@@ -58,7 +57,7 @@ Living document for performance and maintainability work in PDF Wizard. **Last u
 | Phase | Focus |
 |-------|--------|
 | **A** | TS `unknown` + error helper; `strconv.Atoi`; `removeIfExists` tidy |
-| **B** | `GetPDFMetadata` stat dedup; Split API research |
+| **B** | `GetPDFMetadata` stat dedup |
 | **C** | React perf and deeper tab abstraction as needed |
 
 ---

--- a/pdf_wizard/services/DESIGN.md
+++ b/pdf_wizard/services/DESIGN.md
@@ -145,7 +145,7 @@ Splits a PDF into multiple files according to split definitions.
 
 - Validates input file exists and is a PDF
 - Validates output directory exists and is writable
-- Gets PDF page count for validation
+- Reads the PDF once (`api.ReadValidateAndOptimize` with trim command); uses `ctx.PageCount` for range checks
 - Validates all splits:
   - Start page >= 1 and <= totalPages
   - End page >= startPage and <= totalPages
@@ -154,14 +154,10 @@ Splits a PDF into multiple files according to split definitions.
 
 **Implementation:**
 
-- Uses `pdfcpu` library (`api.TrimFile()`) to extract page ranges
-- Processes each split sequentially
-- For each split:
-  - Creates output path: `outputDirectory/filename.pdf`
-  - Removes existing output file if it exists
-  - Uses `TrimFile()` with page range string (e.g., "1-10")
-  - Validates split file was created
-- pdfcpu uses 1-based page numbers
+- Opens the input once and builds a shared context via `api.ReadValidateAndOptimize` (same pipeline as `api.Trim` / `api.TrimFile`, issue #57)
+- For each split: `api.PagesForPageSelection` → `pdfcpu.ExtractPages` from that context → `api.WriteContextFile` to `outputDirectory/filename.pdf`
+- Avoids per-segment `api.TrimFile` calls, which each reopen and reparse the source
+- Removes existing output files before writing; pdfcpu uses 1-based page numbers
 
 **Error Handling:**
 
@@ -272,8 +268,9 @@ App-wide Go and npm dependencies are summarized in [SYSTEM_DESIGN.md § Technica
 
   - `ReadContextFile()` - Read PDF and get context
   - `MergeCreateFile()` - Merge multiple PDFs
-  - `TrimFile()` - Extract page ranges (used for splitting)
-  - `RotateFile()` - Rotate pages in PDF
+  - `ReadValidateAndOptimize()`, `PagesForPageSelection()`, `WriteContextFile()`, `ValidateContext()` — split uses one optimized read then per-output writes (#57)
+
+- `github.com/pdfcpu/pdfcpu/pkg/pdfcpu` - Page extraction (`ExtractPages` for split segments)
 
 - `github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model` - Configuration models
 

--- a/pdf_wizard/services/pdf_service.go
+++ b/pdf_wizard/services/pdf_service.go
@@ -6,9 +6,11 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/pdfcpu/pdfcpu/pkg/api"
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/color"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/types"
@@ -92,11 +94,22 @@ func (s *PDFService) SplitPDF(inputPath string, splits []models.SplitDefinition,
 		return err
 	}
 
-	// Get PDF page count for validation
-	totalPages, err := s.fileService.GetPDFPageCount(inputPath)
+	// Single read+validate+optimize of the source (#57): reuse ctx for every segment
+	// instead of calling api.TrimFile per split (each TrimFile reopens and reparses).
+	config := model.NewDefaultConfiguration()
+	config.Cmd = model.TRIM
+
+	f, err := os.Open(inputPath)
 	if err != nil {
-		return fmt.Errorf("failed to get page count: %w", err)
+		return fmt.Errorf("failed to open input PDF: %w", err)
 	}
+	defer f.Close()
+
+	ctx, err := api.ReadValidateAndOptimize(f, config)
+	if err != nil {
+		return fmt.Errorf("failed to read PDF for split: %w", err)
+	}
+	totalPages := ctx.PageCount
 
 	// Validate all splits
 	for i, split := range splits {
@@ -121,34 +134,58 @@ func (s *PDFService) SplitPDF(inputPath string, splits []models.SplitDefinition,
 		filenameMap[filename] = true
 	}
 
-	// Use pdfcpu to split the PDF
-	config := model.NewDefaultConfiguration()
-
-	// Process each split
+	// Process each split: extract from the shared in-memory context (same as api.Trim).
 	for i, split := range splits {
-		// Create output path
 		outputPath := filepath.Join(outputDirectory, strings.TrimSpace(split.Filename)+PDFExtension)
 
-		// Remove existing output file if it exists
 		if err := removeIfExists(outputPath); err != nil {
 			return err
 		}
 
-		// Use TrimFile to extract the page range
-		// pdfcpu uses 1-based page numbers and TrimFile keeps only the specified pages
 		pageRange := fmt.Sprintf("%d-%d", split.StartPage, split.EndPage)
-		err := api.TrimFile(inputPath, outputPath, []string{pageRange}, config)
+		pages, err := api.PagesForPageSelection(ctx.PageCount, []string{pageRange}, false, true)
 		if err != nil {
 			return fmt.Errorf("failed to trim pages for split %d (pages %d-%d): %w", i+1, split.StartPage, split.EndPage, err)
 		}
 
-		// Validate the split file was created
+		pageNrs := intSetToSortedPages(pages)
+		if len(pageNrs) == 0 {
+			return fmt.Errorf("split %d: no pages selected for range %s", i+1, pageRange)
+		}
+
+		ctxDest, err := pdfcpu.ExtractPages(ctx, pageNrs, false)
+		if err != nil {
+			return fmt.Errorf("failed to trim pages for split %d (pages %d-%d): %w", i+1, split.StartPage, split.EndPage, err)
+		}
+
+		if config.PostProcessValidate {
+			if err := api.ValidateContext(ctxDest); err != nil {
+				return fmt.Errorf("failed to trim pages for split %d (pages %d-%d): %w", i+1, split.StartPage, split.EndPage, err)
+			}
+		}
+
+		if err := api.WriteContextFile(ctxDest, outputPath); err != nil {
+			return fmt.Errorf("failed to write split %d (pages %d-%d): %w", i+1, split.StartPage, split.EndPage, err)
+		}
+
 		if _, err := os.Stat(outputPath); os.IsNotExist(err) {
 			return fmt.Errorf("split file was not created at: %s", outputPath)
 		}
 	}
 
 	return nil
+}
+
+// intSetToSortedPages converts pdfcpu's page selection set to sorted 1-based page numbers (same as api.Trim).
+func intSetToSortedPages(pages types.IntSet) []int {
+	var pageNrs []int
+	for k, v := range pages {
+		if v {
+			pageNrs = append(pageNrs, k)
+		}
+	}
+	sort.Ints(pageNrs)
+	return pageNrs
 }
 
 // RotatePDF rotates specified page ranges in a PDF file


### PR DESCRIPTION
## Summary

Implements [issue #57](https://github.com/shihanxiong/PDF_Wizard/issues/57): stop calling `api.TrimFile` once per split segment (each call reopens and runs `ReadValidateAndOptimize` on the source). `SplitPDF` now mirrors pdfcpu’s own split path: **one** `api.ReadValidateAndOptimize` with `model.TRIM`, then for each definition `api.PagesForPageSelection` → `pdfcpu.ExtractPages` → `api.WriteContextFile`.

Page-range validation uses `ctx.PageCount` from that single read, so split no longer does an extra `GetPDFPageCount` / `ReadContextFile` pass before trimming.

## Docs

- `pdf_wizard/services/DESIGN.md`, `SYSTEM_DESIGN.md`, `pdf_wizard/OPTIMIZATION_REPORT.md` updated to describe the new flow and mark the backlog item done.

Closes #57

Made with [Cursor](https://cursor.com)