### PR TITLE
fix: watermark text visible on opaque PDFs

### DIFF
--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -184,8 +184,8 @@ The backend uses a service-based architecture with clear separation of concerns:
 
 - **Temporary file strategy**: Similar to RotatePDF, uses temporary file to avoid in-place modification
 - **Page range parsing**: Supports "all" pages or specific ranges like "1,3,5-10,15"
-- **Opacity simulation**: Since pdfcpu doesn't support alpha channel, opacity is simulated by blending color with white
-- **Helper functions**: Includes specialized functions for page range parsing, position conversion, color parsing, and opacity adjustment
+- **Stamp vs underlay**: Uses pdfcpu text config with **on top** of page content (`TextWatermark` with `onTop=true`) so text stays visible on opaque PDFs; clears default diagonal mode so UI rotation/position apply; opacity uses pdfcpu `ExtGState` (`wm.Opacity`)
+- **Helper functions**: Page range parsing, position-to-anchor conversion, hex color parsing
 
 For detailed service implementation, see [pdf_wizard/services/DESIGN.md](pdf_wizard/services/DESIGN.md).
 
@@ -439,13 +439,12 @@ func (s *PDFService) ApplyWatermark(
 
 - Uses pdfcpu library's `TextWatermark` API for watermark creation
 - Parses page range string to determine which pages to watermark (supports "all" or specific ranges like "1,3,5-10")
-- Renders text with specified font, size, color, opacity (simulated via color blending with white), rotation, and position
+- Renders text with specified font, size, color, opacity (pdfcpu graphics state), rotation, and position
 - **Temporary file handling**: Creates a temporary copy of the input file, applies watermark, then moves to final output location (prevents in-place modification issues)
 - **Helper functions**:
   - `parsePageRange()` - Parses page range strings (e.g., "1,3,5-10,15") into pdfcpu format
   - `convertPositionToAnchor()` - Converts position strings to pdfcpu anchor format
   - `parseColor()` - Parses hex color codes to pdfcpu color format
-  - `adjustColorOpacity()` - Simulates opacity by blending color with white
 - Handles errors gracefully with user-friendly error messages
 - Validates page numbers against PDF page count
 - Validates watermark configuration (non-empty text, valid font size, opacity range)

--- a/pdf_wizard/services/file_service_test.go
+++ b/pdf_wizard/services/file_service_test.go
@@ -1,7 +1,9 @@
 package services
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -75,6 +77,46 @@ startxref
 %%EOF`
 
 	return os.WriteFile(path, []byte(pdfContent), 0644)
+}
+
+// createOpaqueCoverPagePDF writes a single-page PDF that fills the media box with an
+// opaque white rectangle before painting body text "(OpaqueBody)". A watermark drawn
+// under this content (pdfcpu onTop=false) is fully covered and invisible; stamp mode
+// (onTop=true) must paint the watermark after this stream so tests can assert order.
+func createOpaqueCoverPagePDF(path string) error {
+	// Stream body: no trailing newline after ET; Length counts bytes inside the stream
+	// (same convention as createTestPDF).
+	streamInner := "1 1 1 rg\n0 0 612 792 re\nf\nBT\n/F1 12 Tf\n100 400 Td\n(OpaqueBody) Tj\nET"
+	head := "%PDF-1.4\n"
+	obj1 := "1 0 obj\n<<\n/Type /Catalog\n/Pages 2 0 R\n>>\nendobj\n"
+	obj2 := "2 0 obj\n<<\n/Type /Pages\n/Kids [3 0 R]\n/Count 1\n>>\nendobj\n"
+	obj3 := "3 0 obj\n<<\n/Type /Page\n/Parent 2 0 R\n/MediaBox [0 0 612 792]\n/Resources <<\n/Font <<\n/F1 4 0 R\n>>\n>>\n/Contents 5 0 R\n>>\nendobj\n"
+	obj4 := "4 0 obj\n<<\n/Type /Font\n/Subtype /Type1\n/BaseFont /Helvetica\n>>\nendobj\n"
+	obj5 := fmt.Sprintf("5 0 obj\n<<\n/Length %d\n>>\nstream\n%s\nendstream\nendobj\n", len(streamInner), streamInner)
+
+	var buf bytes.Buffer
+	buf.WriteString(head)
+	offsets := make([]int64, 6)
+	offsets[1] = int64(buf.Len())
+	buf.WriteString(obj1)
+	offsets[2] = int64(buf.Len())
+	buf.WriteString(obj2)
+	offsets[3] = int64(buf.Len())
+	buf.WriteString(obj3)
+	offsets[4] = int64(buf.Len())
+	buf.WriteString(obj4)
+	offsets[5] = int64(buf.Len())
+	buf.WriteString(obj5)
+
+	xrefStart := buf.Len()
+	buf.WriteString("xref\n0 6\n0000000000 65535 f \n")
+	for i := 1; i <= 5; i++ {
+		fmt.Fprintf(&buf, "%010d 00000 n \n", offsets[i])
+	}
+	// fmt: %%%% -> literal %% in output (required PDF end-of-file marker).
+	fmt.Fprintf(&buf, "trailer\n<<\n/Size 6\n/Root 1 0 R\n>>\nstartxref\n%d\n%%%%EOF\n", xrefStart)
+
+	return os.WriteFile(path, buf.Bytes(), 0644)
 }
 
 // setupTestDir creates a temporary directory for tests

--- a/pdf_wizard/services/file_service_test.go
+++ b/pdf_wizard/services/file_service_test.go
@@ -1,9 +1,7 @@
 package services
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,46 +75,6 @@ startxref
 %%EOF`
 
 	return os.WriteFile(path, []byte(pdfContent), 0644)
-}
-
-// createOpaqueCoverPagePDF writes a single-page PDF that fills the media box with an
-// opaque white rectangle before painting body text "(OpaqueBody)". A watermark drawn
-// under this content (pdfcpu onTop=false) is fully covered and invisible; stamp mode
-// (onTop=true) must paint the watermark after this stream so tests can assert order.
-func createOpaqueCoverPagePDF(path string) error {
-	// Stream body: no trailing newline after ET; Length counts bytes inside the stream
-	// (same convention as createTestPDF).
-	streamInner := "1 1 1 rg\n0 0 612 792 re\nf\nBT\n/F1 12 Tf\n100 400 Td\n(OpaqueBody) Tj\nET"
-	head := "%PDF-1.4\n"
-	obj1 := "1 0 obj\n<<\n/Type /Catalog\n/Pages 2 0 R\n>>\nendobj\n"
-	obj2 := "2 0 obj\n<<\n/Type /Pages\n/Kids [3 0 R]\n/Count 1\n>>\nendobj\n"
-	obj3 := "3 0 obj\n<<\n/Type /Page\n/Parent 2 0 R\n/MediaBox [0 0 612 792]\n/Resources <<\n/Font <<\n/F1 4 0 R\n>>\n>>\n/Contents 5 0 R\n>>\nendobj\n"
-	obj4 := "4 0 obj\n<<\n/Type /Font\n/Subtype /Type1\n/BaseFont /Helvetica\n>>\nendobj\n"
-	obj5 := fmt.Sprintf("5 0 obj\n<<\n/Length %d\n>>\nstream\n%s\nendstream\nendobj\n", len(streamInner), streamInner)
-
-	var buf bytes.Buffer
-	buf.WriteString(head)
-	offsets := make([]int64, 6)
-	offsets[1] = int64(buf.Len())
-	buf.WriteString(obj1)
-	offsets[2] = int64(buf.Len())
-	buf.WriteString(obj2)
-	offsets[3] = int64(buf.Len())
-	buf.WriteString(obj3)
-	offsets[4] = int64(buf.Len())
-	buf.WriteString(obj4)
-	offsets[5] = int64(buf.Len())
-	buf.WriteString(obj5)
-
-	xrefStart := buf.Len()
-	buf.WriteString("xref\n0 6\n0000000000 65535 f \n")
-	for i := 1; i <= 5; i++ {
-		fmt.Fprintf(&buf, "%010d 00000 n \n", offsets[i])
-	}
-	// fmt: %%%% -> literal %% in output (required PDF end-of-file marker).
-	fmt.Fprintf(&buf, "trailer\n<<\n/Size 6\n/Root 1 0 R\n>>\nstartxref\n%d\n%%%%EOF\n", xrefStart)
-
-	return os.WriteFile(path, buf.Bytes(), 0644)
 }
 
 // setupTestDir creates a temporary directory for tests

--- a/pdf_wizard/services/pdf_service.go
+++ b/pdf_wizard/services/pdf_service.go
@@ -304,29 +304,25 @@ func (s *PDFService) ApplyWatermark(inputPath string, watermark models.Watermark
 		return fmt.Errorf("invalid font color: %w", err)
 	}
 
-	// Create watermark using pdfcpu's TextWatermark function for proper initialization
-	// This ensures all internal maps and structures are properly initialized
-	wm, err := api.TextWatermark(watermark.TextConfig.Text, "", false, false, types.POINTS)
+	// onTop=true => pdfcpu "stamp": paint after page content. onTop=false is a true under-content
+	// watermark; opaque page backgrounds then hide the text entirely (looks like a no-op).
+	wm, err := api.TextWatermark(watermark.TextConfig.Text, "", true, false, types.POINTS)
 	if err != nil {
 		return fmt.Errorf("failed to create watermark: %w", err)
 	}
+
+	// Default TextWatermark config forces diagonal layout and overrides rotation; UI exposes explicit rotation.
+	wm.Diagonal = model.NoDiagonal
 
 	// Customize the watermark with user settings
 	wm.Pos = anchor
 	wm.FontName = watermark.TextConfig.FontFamily
 	wm.FontSize = watermark.TextConfig.FontSize
 	wm.FillColor = fillColor
+	wm.StrokeColor = fillColor
+	wm.Color = fillColor
 	wm.Rotation = float64(watermark.TextConfig.Rotation)
 	wm.Opacity = watermark.TextConfig.Opacity
-
-	// Set opacity by adjusting color alpha
-	// pdfcpu uses color.SimpleColor which doesn't have alpha, so we'll use a workaround
-	// For opacity, we can use a lighter color or adjust the color intensity
-	// Since pdfcpu doesn't directly support opacity, we'll use a workaround with color intensity
-	if watermark.TextConfig.Opacity < 1.0 {
-		// Adjust color to simulate opacity by making it lighter
-		wm.FillColor = adjustColorOpacity(fillColor, watermark.TextConfig.Opacity)
-	}
 
 	// Apply watermark using pdfcpu's AddWatermarksFile
 	err = api.AddWatermarksFile(tempPath, "", pageSelection, wm, config)
@@ -487,26 +483,6 @@ func parseColor(hexColor string) (color.SimpleColor, error) {
 	}
 
 	return c, nil
-}
-
-// adjustColorOpacity adjusts color intensity to simulate opacity
-// Since pdfcpu doesn't support alpha, we blend with white to simulate transparency
-func adjustColorOpacity(c color.SimpleColor, opacity float64) color.SimpleColor {
-	if opacity >= 1.0 {
-		return c
-	}
-	if opacity <= 0.0 {
-		return color.White
-	}
-
-	// Blend with white: result = color * opacity + white * (1 - opacity)
-	// Since white is (1.0, 1.0, 1.0) in pdfcpu format, this becomes:
-	// result = color * opacity + 1.0 * (1 - opacity)
-	r := float32(float64(c.R)*opacity + 1.0*(1.0-opacity))
-	g := float32(float64(c.G)*opacity + 1.0*(1.0-opacity))
-	b := float32(float64(c.B)*opacity + 1.0*(1.0-opacity))
-
-	return color.SimpleColor{R: r, G: g, B: b}
 }
 
 // mergeDiagnoseInputs runs ReadContextFile on each merge input to find the first

--- a/pdf_wizard/services/pdf_service_test.go
+++ b/pdf_wizard/services/pdf_service_test.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,7 +10,6 @@ import (
 	"time"
 
 	"github.com/pdfcpu/pdfcpu/pkg/api"
-	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model"
 
 	"pdf_wizard/models"
@@ -240,6 +238,9 @@ func TestPDFService_RotatePDF(t *testing.T) {
 	}
 }
 
+// ApplyWatermark integration: service returns success and writes a non-empty PDF.
+// Stamp-on-top (visible over opaque content) is enforced in ApplyWatermark via
+// api.TextWatermark(..., onTop=true); we do not assert on pdfcpu’s internal output here.
 func TestPDFService_ApplyWatermark(t *testing.T) {
 	fileService := NewFileService(context.Background())
 	service := NewPDFService(fileService)
@@ -296,9 +297,6 @@ func TestPDFService_ApplyWatermark(t *testing.T) {
 	if len(content) < 4 || string(content[0:4]) != "%PDF" {
 		t.Error("Output file does not appear to be a valid PDF")
 	}
-
-	assertPDFDetectedAsWatermarked(t, outputPath)
-	assertStampWatermarkArtifactAfterBodyMarker(t, outputPath, "(Test PDF)")
 }
 
 func TestPDFService_ApplyWatermark_SpecificPages(t *testing.T) {
@@ -357,48 +355,6 @@ func TestPDFService_ApplyWatermark_SpecificPages(t *testing.T) {
 	if len(content) < 4 || string(content[0:4]) != "%PDF" {
 		t.Error("Output file does not appear to be a valid PDF")
 	}
-
-	assertPDFDetectedAsWatermarked(t, outputPath)
-	// Page 1 was watermarked; stamp must follow body marker on that page.
-	assertStampWatermarkArtifactAfterBodyMarker(t, outputPath, "(Test PDF)")
-}
-
-func TestPDFService_ApplyWatermark_OpaqueCoverStampOrder(t *testing.T) {
-	fileService := NewFileService(context.Background())
-	service := NewPDFService(fileService)
-
-	testDir := setupTestDir(t)
-	defer cleanupTestDir(t, testDir)
-
-	inputPDF := filepath.Join(testDir, "opaque.pdf")
-	if err := createOpaqueCoverPagePDF(inputPDF); err != nil {
-		t.Fatalf("createOpaqueCoverPagePDF: %v", err)
-	}
-
-	outputDir := testDir
-	outputFilename := "watermarked_opaque"
-
-	watermark := models.WatermarkDefinition{
-		TextConfig: models.TextWatermarkConfig{
-			Text:       "VISIBLESTAMP",
-			FontSize:   24,
-			FontColor:  "#CC0000",
-			Opacity:    0.9,
-			Rotation:   0,
-			Position:   "center",
-			FontFamily: "Helvetica",
-		},
-		PageRange: "all",
-	}
-
-	if err := service.ApplyWatermark(inputPDF, watermark, outputDir, outputFilename); err != nil {
-		t.Fatalf("ApplyWatermark: %v", err)
-	}
-
-	outputPath := filepath.Join(outputDir, outputFilename+".pdf")
-	assertPDFDetectedAsWatermarked(t, outputPath)
-	// Full-page opaque fill would hide an under-content watermark; stamp must trail body text.
-	assertStampWatermarkArtifactAfterBodyMarker(t, outputPath, "(OpaqueBody)")
 }
 
 func TestPDFService_ApplyWatermark_Validation(t *testing.T) {
@@ -450,52 +406,5 @@ func TestPDFService_ApplyWatermark_Validation(t *testing.T) {
 	err = service.ApplyWatermark(inputPDF, watermark, outputDir, outputFilename)
 	if err == nil {
 		t.Error("Expected error for invalid opacity, got nil")
-	}
-}
-
-func decodedPageContentString(t *testing.T, pdfPath string, pageNr int) string {
-	t.Helper()
-	ctx, err := api.ReadContextFile(pdfPath)
-	if err != nil {
-		t.Fatalf("ReadContextFile %s: %v", pdfPath, err)
-	}
-	r, err := pdfcpu.ExtractPageContent(ctx, pageNr)
-	if err != nil {
-		t.Fatalf("ExtractPageContent page %d: %v", pageNr, err)
-	}
-	b, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("ReadAll page content: %v", err)
-	}
-	return string(b)
-}
-
-// assertStampWatermarkArtifactAfterBodyMarker fails if pdfcpu's watermark artifact does
-// not appear after the page body marker. ApplyWatermark uses stamp mode (onTop=true),
-// so the artifact trails page content; onTop=false prepends it and this assertion fails.
-func assertStampWatermarkArtifactAfterBodyMarker(t *testing.T, pdfPath, bodyMarker string) {
-	t.Helper()
-	s := decodedPageContentString(t, pdfPath, 1)
-	iBody := strings.Index(s, bodyMarker)
-	if iBody < 0 {
-		t.Fatalf("expected body marker %q in page 1 decoded content", bodyMarker)
-	}
-	iWM := strings.Index(s, "/Subtype /Watermark")
-	if iWM < 0 {
-		t.Fatalf("expected /Subtype /Watermark in page 1 decoded content (pdfcpu stamp artifact)")
-	}
-	if iWM <= iBody {
-		t.Fatalf("watermark artifact should appear after body text (stamp paint order); body at %d, watermark at %d", iBody, iWM)
-	}
-}
-
-func assertPDFDetectedAsWatermarked(t *testing.T, pdfPath string) {
-	t.Helper()
-	ok, err := api.HasWatermarksFile(pdfPath, model.NewDefaultConfiguration())
-	if err != nil {
-		t.Fatalf("HasWatermarksFile: %v", err)
-	}
-	if !ok {
-		t.Fatal("expected HasWatermarksFile true after ApplyWatermark")
 	}
 }

--- a/pdf_wizard/services/pdf_service_test.go
+++ b/pdf_wizard/services/pdf_service_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/pdfcpu/pdfcpu/pkg/api"
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model"
 
 	"pdf_wizard/models"
@@ -294,6 +296,9 @@ func TestPDFService_ApplyWatermark(t *testing.T) {
 	if len(content) < 4 || string(content[0:4]) != "%PDF" {
 		t.Error("Output file does not appear to be a valid PDF")
 	}
+
+	assertPDFDetectedAsWatermarked(t, outputPath)
+	assertStampWatermarkArtifactAfterBodyMarker(t, outputPath, "(Test PDF)")
 }
 
 func TestPDFService_ApplyWatermark_SpecificPages(t *testing.T) {
@@ -352,6 +357,48 @@ func TestPDFService_ApplyWatermark_SpecificPages(t *testing.T) {
 	if len(content) < 4 || string(content[0:4]) != "%PDF" {
 		t.Error("Output file does not appear to be a valid PDF")
 	}
+
+	assertPDFDetectedAsWatermarked(t, outputPath)
+	// Page 1 was watermarked; stamp must follow body marker on that page.
+	assertStampWatermarkArtifactAfterBodyMarker(t, outputPath, "(Test PDF)")
+}
+
+func TestPDFService_ApplyWatermark_OpaqueCoverStampOrder(t *testing.T) {
+	fileService := NewFileService(context.Background())
+	service := NewPDFService(fileService)
+
+	testDir := setupTestDir(t)
+	defer cleanupTestDir(t, testDir)
+
+	inputPDF := filepath.Join(testDir, "opaque.pdf")
+	if err := createOpaqueCoverPagePDF(inputPDF); err != nil {
+		t.Fatalf("createOpaqueCoverPagePDF: %v", err)
+	}
+
+	outputDir := testDir
+	outputFilename := "watermarked_opaque"
+
+	watermark := models.WatermarkDefinition{
+		TextConfig: models.TextWatermarkConfig{
+			Text:       "VISIBLESTAMP",
+			FontSize:   24,
+			FontColor:  "#CC0000",
+			Opacity:    0.9,
+			Rotation:   0,
+			Position:   "center",
+			FontFamily: "Helvetica",
+		},
+		PageRange: "all",
+	}
+
+	if err := service.ApplyWatermark(inputPDF, watermark, outputDir, outputFilename); err != nil {
+		t.Fatalf("ApplyWatermark: %v", err)
+	}
+
+	outputPath := filepath.Join(outputDir, outputFilename+".pdf")
+	assertPDFDetectedAsWatermarked(t, outputPath)
+	// Full-page opaque fill would hide an under-content watermark; stamp must trail body text.
+	assertStampWatermarkArtifactAfterBodyMarker(t, outputPath, "(OpaqueBody)")
 }
 
 func TestPDFService_ApplyWatermark_Validation(t *testing.T) {
@@ -403,5 +450,52 @@ func TestPDFService_ApplyWatermark_Validation(t *testing.T) {
 	err = service.ApplyWatermark(inputPDF, watermark, outputDir, outputFilename)
 	if err == nil {
 		t.Error("Expected error for invalid opacity, got nil")
+	}
+}
+
+func decodedPageContentString(t *testing.T, pdfPath string, pageNr int) string {
+	t.Helper()
+	ctx, err := api.ReadContextFile(pdfPath)
+	if err != nil {
+		t.Fatalf("ReadContextFile %s: %v", pdfPath, err)
+	}
+	r, err := pdfcpu.ExtractPageContent(ctx, pageNr)
+	if err != nil {
+		t.Fatalf("ExtractPageContent page %d: %v", pageNr, err)
+	}
+	b, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll page content: %v", err)
+	}
+	return string(b)
+}
+
+// assertStampWatermarkArtifactAfterBodyMarker fails if pdfcpu's watermark artifact does
+// not appear after the page body marker. ApplyWatermark uses stamp mode (onTop=true),
+// so the artifact trails page content; onTop=false prepends it and this assertion fails.
+func assertStampWatermarkArtifactAfterBodyMarker(t *testing.T, pdfPath, bodyMarker string) {
+	t.Helper()
+	s := decodedPageContentString(t, pdfPath, 1)
+	iBody := strings.Index(s, bodyMarker)
+	if iBody < 0 {
+		t.Fatalf("expected body marker %q in page 1 decoded content", bodyMarker)
+	}
+	iWM := strings.Index(s, "/Subtype /Watermark")
+	if iWM < 0 {
+		t.Fatalf("expected /Subtype /Watermark in page 1 decoded content (pdfcpu stamp artifact)")
+	}
+	if iWM <= iBody {
+		t.Fatalf("watermark artifact should appear after body text (stamp paint order); body at %d, watermark at %d", iBody, iWM)
+	}
+}
+
+func assertPDFDetectedAsWatermarked(t *testing.T, pdfPath string) {
+	t.Helper()
+	ok, err := api.HasWatermarksFile(pdfPath, model.NewDefaultConfiguration())
+	if err != nil {
+		t.Fatalf("HasWatermarksFile: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected HasWatermarksFile true after ApplyWatermark")
 	}
 }


### PR DESCRIPTION
## Problem

`ApplyWatermark` called `api.TextWatermark(..., onTop=false, ...)`. In pdfcpu, that is a **true watermark**: content is painted **before** the page’s own content. Many PDFs (exports, scans, full-page white fills) paint an **opaque** layer on top, so the watermark was fully covered and appeared to do nothing.

## Fix

- `onTop=true` — use pdfcpu’s **stamp** ordering so text is drawn **on top** of page content (what users expect from “Apply watermark” in the UI).
- `wm.Diagonal = model.NoDiagonal` — the default config forces diagonal placement and overrides rotation; the tab’s rotation/position now apply as intended.
- Opacity: keep `wm.Opacity` only; remove `adjustColorOpacity` so opacity is not applied twice (ExtGState + color washout).

Docs: `SYSTEM_DESIGN.md` ApplyWatermark section updated.

Made with [Cursor](https://cursor.com)