### PR TITLE
Use strconv.Atoi for page range integers (#55)

### DIFF
--- a/pdf_wizard/services/pdf_service.go
+++ b/pdf_wizard/services/pdf_service.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/pdfcpu/pdfcpu/pkg/api"
@@ -463,11 +464,9 @@ func parsePageRange(pageRange string, totalPages int) ([]string, error) {
 	return selections, nil
 }
 
-// parseInt parses a string to int
+// parseInt parses a string to int.
 func parseInt(s string) (int, error) {
-	var result int
-	_, err := fmt.Sscanf(s, "%d", &result)
-	return result, err
+	return strconv.Atoi(s)
 }
 
 // convertPositionToAnchor converts position string to pdfcpu anchor format


### PR DESCRIPTION
Closes #55.

`parseInt` (used by `parsePageRange` for watermark page selections) now delegates to `strconv.Atoi` instead of `fmt.Sscanf`, which is clearer and avoids the scanf machinery for simple decimal integers.

Behavior note: inputs must be a valid integer string in full (e.g. `"12"` only), not a numeric prefix.

Made with [Cursor](https://cursor.com)