### PR TITLE
fix(watermark): apply font size in points (pdfcpu scale)

### DIFF
--- a/pdf_wizard/services/pdf_service.go
+++ b/pdf_wizard/services/pdf_service.go
@@ -351,6 +351,13 @@ func (s *PDFService) ApplyWatermark(inputPath string, watermark models.Watermark
 	// Default TextWatermark config forces diagonal layout and overrides rotation; UI exposes explicit rotation.
 	wm.Diagonal = model.NoDiagonal
 
+	// Default relative Scale (0.5) makes model.scaleFontSize derive an effective size from
+	// page width × scale × FontSize / textWidth; text width scales with FontSize, so the
+	// ratio largely cancels and the stamp looks the same for different UI font sizes.
+	// Absolute scale 1 honors FontSize as points (see pdfcpu examples: "scale:1 abs").
+	wm.ScaleAbs = true
+	wm.Scale = 1.0
+
 	// Customize the watermark with user settings
 	wm.Pos = anchor
 	wm.FontName = watermark.TextConfig.FontFamily


### PR DESCRIPTION
## Problem
The Watermark tab sends `fontSize` (12–72 pt) to the backend and `ApplyWatermark` sets `wm.FontSize`, but the output stamp looked the same for different sizes.

## Cause
pdfcpu’s default text watermark uses **relative** `Scale` (0.5). In `model.scaleFontSize`, relative mode computes an effective size using `pageWidth × scale × FontSize / textWidth`. Text width grows with `FontSize`, so the ratio largely **cancels** `FontSize` for typical one-line watermarks.

## Fix
After `TextWatermark`, set `wm.ScaleAbs = true` and `wm.Scale = 1.0` so `FontSize` is honored as real **points**, consistent with pdfcpu’s own examples (`scale:1 abs`).

## Testing
`go test ./...` under `pdf_wizard`.

Made with [Cursor](https://cursor.com)