### PR TITLE
fix(ui): remove divider above output directory on all tabs

### DIFF
--- a/pdf_wizard/frontend/src/components/ImagesToPdfTab.tsx
+++ b/pdf_wizard/frontend/src/components/ImagesToPdfTab.tsx
@@ -238,7 +238,7 @@ export const ImagesToPdfTab = ({ onFileDrop }: ImagesToPdfTabProps) => {
         <NoPDFSelected />
       )}
 
-      <Box sx={{ mt: 'auto', pt: 2, pb: 2, borderTop: '1px solid', borderColor: 'divider', flexShrink: 0 }}>
+      <Box sx={{ mt: 'auto', pt: 2, pb: 2, flexShrink: 0 }}>
         <OutputDirectorySelector
           directory={outputDirectory}
           onSelect={selectDirectory}

--- a/pdf_wizard/frontend/src/components/MergeTab.tsx
+++ b/pdf_wizard/frontend/src/components/MergeTab.tsx
@@ -252,7 +252,7 @@ export const MergeTab = ({ onFileDrop }: MergeTabProps) => {
       )}
 
       {/* Output Configuration Section */}
-      <Box sx={{ mt: 'auto', pt: 2, pb: 2, borderTop: '1px solid', borderColor: 'divider', flexShrink: 0 }}>
+      <Box sx={{ mt: 'auto', pt: 2, pb: 2, flexShrink: 0 }}>
         <OutputDirectorySelector
           directory={outputDirectory}
           onSelect={selectDirectory}

--- a/pdf_wizard/frontend/src/components/RotateTab.tsx
+++ b/pdf_wizard/frontend/src/components/RotateTab.tsx
@@ -331,8 +331,6 @@ export const RotateTab = ({ onFileDrop }: RotateTabProps) => {
           mt: 'auto',
           pt: 2,
           pb: 2,
-          borderTop: '1px solid',
-          borderColor: 'divider',
           flexShrink: 0,
         }}
       >

--- a/pdf_wizard/frontend/src/components/SplitTab.tsx
+++ b/pdf_wizard/frontend/src/components/SplitTab.tsx
@@ -314,8 +314,6 @@ export const SplitTab = ({ onFileDrop }: SplitTabProps) => {
           mt: 'auto',
           pt: 2,
           pb: 2,
-          borderTop: '1px solid',
-          borderColor: 'divider',
           flexShrink: 0,
         }}
       >

--- a/pdf_wizard/frontend/src/components/WatermarkTab.tsx
+++ b/pdf_wizard/frontend/src/components/WatermarkTab.tsx
@@ -596,8 +596,6 @@ export const WatermarkTab = ({ onFileDrop }: WatermarkTabProps) => {
           mt: 'auto',
           pt: 2,
           pb: 2,
-          borderTop: '1px solid',
-          borderColor: 'divider',
           flexShrink: 0,
         }}
       >


### PR DESCRIPTION
## Summary
Removes the horizontal rule (`borderTop` / theme `divider`) above the output directory block on **Merge**, **Split**, **Rotate**, **Images to PDF**, and **Watermark** tabs so the select-directory control sits flush with the content above.

## Test plan
- [ ] Open each tab and confirm the line above “Select output directory” (or equivalent) is gone and spacing still looks acceptable.

Made with [Cursor](https://cursor.com)