### PR TITLE
[PDF-86] Localize native file and folder dialog titles

### DIFF
--- a/pdf_wizard/DESIGN.md
+++ b/pdf_wizard/DESIGN.md
@@ -178,21 +178,21 @@ Emits a "show-settings" event to the frontend.
 All PDF and file operations delegate to services:
 
 ```go
-// File operations
-func (a *App) SelectPDFFiles() ([]string, error) {
-    return a.fileService.SelectPDFFiles()
+// File operations (labels: dialog title + filter display name for file pickers)
+func (a *App) SelectPDFFiles(labels models.FileDialogLabels) ([]string, error) {
+    return a.fileService.SelectPDFFiles(labels)
 }
 
-func (a *App) SelectPDFFile() (string, error) {
-    return a.fileService.SelectPDFFile()
+func (a *App) SelectPDFFile(labels models.FileDialogLabels) (string, error) {
+    return a.fileService.SelectPDFFile(labels)
 }
 
-func (a *App) SelectImageFiles() ([]string, error) {
-    return a.fileService.SelectImageFiles()
+func (a *App) SelectImageFiles(labels models.FileDialogLabels) ([]string, error) {
+    return a.fileService.SelectImageFiles(labels)
 }
 
-func (a *App) SelectOutputDirectory() (string, error) {
-    return a.fileService.SelectOutputDirectory()
+func (a *App) SelectOutputDirectory(labels models.FileDialogLabels) (string, error) {
+    return a.fileService.SelectOutputDirectory(labels)
 }
 
 func (a *App) GetFileMetadata(path string) (models.PDFMetadata, error) {

--- a/pdf_wizard/app.go
+++ b/pdf_wizard/app.go
@@ -152,18 +152,18 @@ func (a *App) SetLanguage(language string) error {
 }
 
 // SelectPDFFiles opens a file dialog to select multiple PDF files
-func (a *App) SelectPDFFiles() ([]string, error) {
-	return a.fileService.SelectPDFFiles()
+func (a *App) SelectPDFFiles(labels models.FileDialogLabels) ([]string, error) {
+	return a.fileService.SelectPDFFiles(labels)
 }
 
 // SelectPDFFile opens a file dialog to select a single PDF file
-func (a *App) SelectPDFFile() (string, error) {
-	return a.fileService.SelectPDFFile()
+func (a *App) SelectPDFFile(labels models.FileDialogLabels) (string, error) {
+	return a.fileService.SelectPDFFile(labels)
 }
 
 // SelectOutputDirectory opens a directory dialog to select output directory
-func (a *App) SelectOutputDirectory() (string, error) {
-	return a.fileService.SelectOutputDirectory()
+func (a *App) SelectOutputDirectory(labels models.FileDialogLabels) (string, error) {
+	return a.fileService.SelectOutputDirectory(labels)
 }
 
 // GetFileMetadata retrieves file metadata (TotalPages will be 0 unless needed)
@@ -187,8 +187,8 @@ func (a *App) MergePDFs(inputPaths []string, outputDirectory string, outputFilen
 }
 
 // SelectImageFiles opens a dialog to select multiple image files.
-func (a *App) SelectImageFiles() ([]string, error) {
-	return a.fileService.SelectImageFiles()
+func (a *App) SelectImageFiles(labels models.FileDialogLabels) ([]string, error) {
+	return a.fileService.SelectImageFiles(labels)
 }
 
 // ImagesToPDF writes a PDF with one page per image in the given order.

--- a/pdf_wizard/frontend/e2e/helpers/test-setup.ts
+++ b/pdf_wizard/frontend/e2e/helpers/test-setup.ts
@@ -81,10 +81,10 @@ export function setupWailsMocks() {
             (window as any).runtime.EventsEmit('show-settings');
           }
         },
-        SelectPDFFiles: async () => [],
-        SelectPDFFile: async () => pdfPath || '',
-        SelectOutputDirectory: async () => '/tmp',
-        SelectImageFiles: async () => {
+        SelectPDFFiles: async (_labels: unknown) => [],
+        SelectPDFFile: async (_labels: unknown) => pdfPath || '',
+        SelectOutputDirectory: async (_labels: unknown) => '/tmp',
+        SelectImageFiles: async (_labels: unknown) => {
           const paths = (window as any).__testImagePaths as string[] | undefined;
           return paths && paths.length ? [...paths] : [];
         },

--- a/pdf_wizard/frontend/src/components/ImagesToPdfTab.tsx
+++ b/pdf_wizard/frontend/src/components/ImagesToPdfTab.tsx
@@ -139,7 +139,7 @@ export const ImagesToPdfTab = ({ onFileDrop }: ImagesToPdfTabProps) => {
   const [qrDataURL, setQrDataURL] = useState<string | null>(null);
 
   const { handleImageDrop } = useImageDrop();
-  const { outputDirectory, selectDirectory } = useOutputDirectory('failedToSelectOutputDirectory');
+  const { outputDirectory, selectDirectory } = useOutputDirectory('failedToSelectOutputDirectory', 'selectOutputDirectory');
   const { error, setError, handleError } = useErrorHandler();
 
   useEffect(() => {
@@ -240,7 +240,12 @@ export const ImagesToPdfTab = ({ onFileDrop }: ImagesToPdfTabProps) => {
 
   const handleSelectFiles = async () => {
     try {
-      const paths = await SelectImageFiles();
+      const paths = await SelectImageFiles(
+        new models.FileDialogLabels({
+          title: t('selectImageFiles'),
+          filterDisplayName: t('fileDialogFilterImages'),
+        }),
+      );
       if (paths && paths.length > 0) {
         const metadataPromises = paths.map((path) => GetFileMetadata(path));
         const metadataResults = await Promise.all(metadataPromises);

--- a/pdf_wizard/frontend/src/components/MergeTab.tsx
+++ b/pdf_wizard/frontend/src/components/MergeTab.tsx
@@ -21,6 +21,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { SelectPDFFiles, GetFileMetadata, MergePDFs } from '../../wailsjs/go/main/App';
+import { models } from '../../wailsjs/go/models';
 import { SelectedFile } from '../types';
 import { formatFileSize, formatDate, convertToSelectedFile } from '../utils/formatters';
 import { useI18n } from '../utils/i18n';
@@ -122,7 +123,7 @@ export const MergeTab = ({ onFileDrop }: MergeTabProps) => {
   const [success, setSuccess] = useState<string | null>(null);
 
   const { handlePDFDrop } = usePDFDrop();
-  const { outputDirectory, selectDirectory } = useOutputDirectory('failedToSelectOutputDirectory');
+  const { outputDirectory, selectDirectory } = useOutputDirectory('failedToSelectOutputDirectory', 'selectOutputDirectory');
   const { error, setError, handleError } = useErrorHandler();
 
   // Register drag and drop handler with App component
@@ -144,7 +145,12 @@ export const MergeTab = ({ onFileDrop }: MergeTabProps) => {
 
   const handleSelectFiles = async () => {
     try {
-      const paths = await SelectPDFFiles();
+      const paths = await SelectPDFFiles(
+        new models.FileDialogLabels({
+          title: t('selectPDFFiles'),
+          filterDisplayName: t('fileDialogFilterPdfFiles'),
+        }),
+      );
       if (paths && paths.length > 0) {
         const metadataPromises = paths.map((path) => GetFileMetadata(path));
         const metadataResults = await Promise.all(metadataPromises);

--- a/pdf_wizard/frontend/src/components/RotateTab.tsx
+++ b/pdf_wizard/frontend/src/components/RotateTab.tsx
@@ -44,7 +44,10 @@ export const RotateTab = ({ onFileDrop }: RotateTabProps) => {
   const [success, setSuccess] = useState<string | null>(null);
 
   const { handlePDFDrop } = usePDFDrop();
-  const { outputDirectory, selectDirectory } = useOutputDirectory('failedToSelectOutputDirectoryRotate');
+  const { outputDirectory, selectDirectory } = useOutputDirectory(
+    'failedToSelectOutputDirectoryRotate',
+    'selectOutputDirectoryRotate',
+  );
   const { error, setError, handleError } = useErrorHandler();
 
   // Register drag and drop handler with App component
@@ -67,7 +70,12 @@ export const RotateTab = ({ onFileDrop }: RotateTabProps) => {
 
   const handleSelectPDF = async () => {
     try {
-      const path = await SelectPDFFile();
+      const path = await SelectPDFFile(
+        new models.FileDialogLabels({
+          title: t('selectPDFFile'),
+          filterDisplayName: t('fileDialogFilterPdfFiles'),
+        }),
+      );
       if (path) {
         const metadata = await GetPDFMetadata(path);
         setSelectedPDF({

--- a/pdf_wizard/frontend/src/components/SplitTab.tsx
+++ b/pdf_wizard/frontend/src/components/SplitTab.tsx
@@ -38,7 +38,10 @@ export const SplitTab = ({ onFileDrop }: SplitTabProps) => {
   const [success, setSuccess] = useState<string | null>(null);
 
   const { handlePDFDrop } = usePDFDrop();
-  const { outputDirectory, selectDirectory } = useOutputDirectory('failedToSelectOutputDirectorySplit');
+  const { outputDirectory, selectDirectory } = useOutputDirectory(
+    'failedToSelectOutputDirectorySplit',
+    'selectOutputDirectorySplit',
+  );
   const { error, setError, handleError } = useErrorHandler();
 
   // Register drag and drop handler with App component
@@ -61,7 +64,12 @@ export const SplitTab = ({ onFileDrop }: SplitTabProps) => {
 
   const handleSelectPDF = async () => {
     try {
-      const path = await SelectPDFFile();
+      const path = await SelectPDFFile(
+        new models.FileDialogLabels({
+          title: t('selectPDFFile'),
+          filterDisplayName: t('fileDialogFilterPdfFiles'),
+        }),
+      );
       if (path) {
         const metadata = await GetPDFMetadata(path);
         setSelectedPDF({

--- a/pdf_wizard/frontend/src/components/WatermarkTab.tsx
+++ b/pdf_wizard/frontend/src/components/WatermarkTab.tsx
@@ -91,7 +91,12 @@ export const WatermarkTab = ({ onFileDrop }: WatermarkTabProps) => {
 
   const handleSelectPDF = async () => {
     try {
-      const path = await SelectPDFFile();
+      const path = await SelectPDFFile(
+        new models.FileDialogLabels({
+          title: t('selectPDFFileWatermark'),
+          filterDisplayName: t('fileDialogFilterPdfFiles'),
+        }),
+      );
       if (path) {
         const metadata = await GetPDFMetadata(path);
         setSelectedPDF({
@@ -112,7 +117,9 @@ export const WatermarkTab = ({ onFileDrop }: WatermarkTabProps) => {
 
   const handleSelectOutputDirectory = async () => {
     try {
-      const dir = await SelectOutputDirectory();
+      const dir = await SelectOutputDirectory(
+        new models.FileDialogLabels({ title: t('selectOutputDirectoryWatermark'), filterDisplayName: '' }),
+      );
       if (dir) {
         setOutputDirectory(dir);
         setError(null);

--- a/pdf_wizard/frontend/src/hooks/useOutputDirectory.ts
+++ b/pdf_wizard/frontend/src/hooks/useOutputDirectory.ts
@@ -1,18 +1,23 @@
 import { useState, useCallback } from 'react';
 import { SelectOutputDirectory } from '../../wailsjs/go/main/App';
+import { models } from '../../wailsjs/go/models';
 import { useErrorHandler } from './useErrorHandler';
+import { useI18n } from '../utils/i18n';
 import { type Translations } from '../utils/i18n';
 
 /**
  * Hook for managing output directory selection with consistent error handling
  */
-export function useOutputDirectory(errorKey: keyof Translations) {
+export function useOutputDirectory(errorKey: keyof Translations, dialogTitleKey: keyof Translations) {
   const [outputDirectory, setOutputDirectory] = useState<string>('');
   const { handleError, setError } = useErrorHandler();
+  const { t } = useI18n();
 
   const selectDirectory = useCallback(async () => {
     try {
-      const dir = await SelectOutputDirectory();
+      const dir = await SelectOutputDirectory(
+        new models.FileDialogLabels({ title: t(dialogTitleKey), filterDisplayName: '' }),
+      );
       if (dir) {
         setOutputDirectory(dir);
         setError(null);
@@ -20,7 +25,7 @@ export function useOutputDirectory(errorKey: keyof Translations) {
     } catch (err) {
       handleError(err, errorKey);
     }
-  }, [errorKey, handleError, setError]);
+  }, [dialogTitleKey, errorKey, handleError, setError, t]);
 
   return {
     outputDirectory,

--- a/pdf_wizard/frontend/src/utils/i18n/ar.ts
+++ b/pdf_wizard/frontend/src/utils/i18n/ar.ts
@@ -22,6 +22,8 @@ export const ar: Translations = {
   failedToLoadFiles: 'فشل تحميل الملفات:',
   failedToSelectFiles: 'فشل اختيار الملفات:',
   failedToSelectOutputDirectory: 'فشل اختيار مجلد الإخراج:',
+  fileDialogFilterPdfFiles: 'ملفات PDF',
+  fileDialogFilterImages: 'صور',
   selectPDFFile: 'اختر ملف PDF',
   dragDropPDFHint: 'أو اسحب وأفلت ملف PDF في أي مكان على النافذة',
   addSplit: 'إضافة تقسيم',

--- a/pdf_wizard/frontend/src/utils/i18n/de.ts
+++ b/pdf_wizard/frontend/src/utils/i18n/de.ts
@@ -22,6 +22,8 @@ export const de: Translations = {
   failedToLoadFiles: 'Dateien konnten nicht geladen werden:',
   failedToSelectFiles: 'Dateien konnten nicht ausgewählt werden:',
   failedToSelectOutputDirectory: 'Ausgabeverzeichnis konnte nicht ausgewählt werden:',
+  fileDialogFilterPdfFiles: 'PDF-Dateien',
+  fileDialogFilterImages: 'Bilder',
   selectPDFFile: 'PDF-Datei auswählen',
   dragDropPDFHint: 'Oder eine PDF-Datei an eine beliebige Stelle im Fenster ziehen und ablegen',
   addSplit: 'Teilung hinzufügen',

--- a/pdf_wizard/frontend/src/utils/i18n/en.ts
+++ b/pdf_wizard/frontend/src/utils/i18n/en.ts
@@ -22,6 +22,8 @@ export const en: Translations = {
   failedToLoadFiles: 'Failed to load files:',
   failedToSelectFiles: 'Failed to select files:',
   failedToSelectOutputDirectory: 'Failed to select output directory:',
+  fileDialogFilterPdfFiles: 'PDF files',
+  fileDialogFilterImages: 'Images',
   selectPDFFile: 'Select PDF File',
   dragDropPDFHint: 'Or drag and drop a PDF file anywhere on the window',
   addSplit: 'Add Split',

--- a/pdf_wizard/frontend/src/utils/i18n/es.ts
+++ b/pdf_wizard/frontend/src/utils/i18n/es.ts
@@ -22,6 +22,8 @@ export const es: Translations = {
   failedToLoadFiles: 'Error al cargar archivos:',
   failedToSelectFiles: 'Error al seleccionar archivos:',
   failedToSelectOutputDirectory: 'Error al seleccionar directorio de salida:',
+  fileDialogFilterPdfFiles: 'Archivos PDF',
+  fileDialogFilterImages: 'Imágenes',
   selectPDFFile: 'Seleccionar archivo PDF',
   dragDropPDFHint: 'O arrastra y suelta un archivo PDF en cualquier lugar de la ventana',
   addSplit: 'Agregar división',

--- a/pdf_wizard/frontend/src/utils/i18n/fr.ts
+++ b/pdf_wizard/frontend/src/utils/i18n/fr.ts
@@ -22,6 +22,8 @@ export const fr: Translations = {
   failedToLoadFiles: 'Échec du chargement des fichiers :',
   failedToSelectFiles: 'Échec de la sélection des fichiers :',
   failedToSelectOutputDirectory: 'Échec de la sélection du répertoire de sortie :',
+  fileDialogFilterPdfFiles: 'Fichiers PDF',
+  fileDialogFilterImages: 'Images',
   selectPDFFile: 'Sélectionner un fichier PDF',
   dragDropPDFHint: 'Ou glissez-déposez un fichier PDF n\'importe où sur la fenêtre',
   addSplit: 'Ajouter une division',

--- a/pdf_wizard/frontend/src/utils/i18n/hi.ts
+++ b/pdf_wizard/frontend/src/utils/i18n/hi.ts
@@ -22,6 +22,8 @@ export const hi: Translations = {
   failedToLoadFiles: 'फ़ाइलें लोड करने में विफल:',
   failedToSelectFiles: 'फ़ाइलें चुनने में विफल:',
   failedToSelectOutputDirectory: 'आउटपुट निर्देशिका चुनने में विफल:',
+  fileDialogFilterPdfFiles: 'PDF फ़ाइलें',
+  fileDialogFilterImages: 'छवियाँ',
   selectPDFFile: 'PDF फ़ाइल चुनें',
   dragDropPDFHint: 'या विंडो पर कहीं भी PDF फ़ाइल खींचें और छोड़ें',
   addSplit: 'विभाजन जोड़ें',

--- a/pdf_wizard/frontend/src/utils/i18n/ja.ts
+++ b/pdf_wizard/frontend/src/utils/i18n/ja.ts
@@ -22,6 +22,8 @@ export const ja: Translations = {
   failedToLoadFiles: 'ファイルの読み込みに失敗しました：',
   failedToSelectFiles: 'ファイルの選択に失敗しました：',
   failedToSelectOutputDirectory: '出力ディレクトリの選択に失敗しました：',
+  fileDialogFilterPdfFiles: 'PDF ファイル',
+  fileDialogFilterImages: '画像',
   selectPDFFile: 'PDF ファイルを選択',
   dragDropPDFHint: 'または、PDF ファイルをウィンドウの任意の場所にドラッグ＆ドロップ',
   addSplit: '分割を追加',

--- a/pdf_wizard/frontend/src/utils/i18n/ko.ts
+++ b/pdf_wizard/frontend/src/utils/i18n/ko.ts
@@ -22,6 +22,8 @@ export const ko: Translations = {
   failedToLoadFiles: '파일 로드 실패:',
   failedToSelectFiles: '파일 선택 실패:',
   failedToSelectOutputDirectory: '출력 디렉토리 선택 실패:',
+  fileDialogFilterPdfFiles: 'PDF 파일',
+  fileDialogFilterImages: '이미지',
   selectPDFFile: 'PDF 파일 선택',
   dragDropPDFHint: '또는 PDF 파일을 창 어디에나 끌어다 놓으세요',
   addSplit: '분할 추가',

--- a/pdf_wizard/frontend/src/utils/i18n/pt.ts
+++ b/pdf_wizard/frontend/src/utils/i18n/pt.ts
@@ -22,6 +22,8 @@ export const pt: Translations = {
   failedToLoadFiles: 'Falha ao carregar arquivos:',
   failedToSelectFiles: 'Falha ao selecionar arquivos:',
   failedToSelectOutputDirectory: 'Falha ao selecionar diretório de saída:',
+  fileDialogFilterPdfFiles: 'Ficheiros PDF',
+  fileDialogFilterImages: 'Imagens',
   selectPDFFile: 'Selecionar arquivo PDF',
   dragDropPDFHint: 'Ou arraste e solte um arquivo PDF em qualquer lugar da janela',
   addSplit: 'Adicionar divisão',

--- a/pdf_wizard/frontend/src/utils/i18n/ru.ts
+++ b/pdf_wizard/frontend/src/utils/i18n/ru.ts
@@ -22,6 +22,8 @@ export const ru: Translations = {
   failedToLoadFiles: 'Ошибка загрузки файлов:',
   failedToSelectFiles: 'Ошибка выбора файлов:',
   failedToSelectOutputDirectory: 'Ошибка выбора папки для сохранения:',
+  fileDialogFilterPdfFiles: 'PDF-файлы',
+  fileDialogFilterImages: 'Изображения',
   selectPDFFile: 'Выбрать PDF файл',
   dragDropPDFHint: 'Или перетащите PDF файл в любое место окна',
   addSplit: 'Добавить разделение',

--- a/pdf_wizard/frontend/src/utils/i18n/types.ts
+++ b/pdf_wizard/frontend/src/utils/i18n/types.ts
@@ -32,6 +32,10 @@ export interface Translations {
   failedToLoadFiles: string;
   failedToSelectFiles: string;
   failedToSelectOutputDirectory: string;
+  /** Native file-dialog filter label for PDFs */
+  fileDialogFilterPdfFiles: string;
+  /** Native file-dialog filter label for raster images */
+  fileDialogFilterImages: string;
 
   // Split Tab
   selectPDFFile: string;

--- a/pdf_wizard/frontend/src/utils/i18n/zh-TW.ts
+++ b/pdf_wizard/frontend/src/utils/i18n/zh-TW.ts
@@ -22,6 +22,8 @@ export const zhTW: Translations = {
   failedToLoadFiles: '載入檔案失敗：',
   failedToSelectFiles: '選擇檔案失敗：',
   failedToSelectOutputDirectory: '選擇輸出目錄失敗：',
+  fileDialogFilterPdfFiles: 'PDF 檔案',
+  fileDialogFilterImages: '圖片',
   selectPDFFile: '選擇 PDF 檔案',
   dragDropPDFHint: '或將 PDF 檔案拖放到視窗任意位置',
   addSplit: '新增拆分',

--- a/pdf_wizard/frontend/src/utils/i18n/zh.ts
+++ b/pdf_wizard/frontend/src/utils/i18n/zh.ts
@@ -22,6 +22,8 @@ export const zh: Translations = {
   failedToLoadFiles: '加载文件失败：',
   failedToSelectFiles: '选择文件失败：',
   failedToSelectOutputDirectory: '选择输出目录失败：',
+  fileDialogFilterPdfFiles: 'PDF 文件',
+  fileDialogFilterImages: '图片',
   selectPDFFile: '选择 PDF 文件',
   dragDropPDFHint: '或将 PDF 文件拖放到窗口任意位置',
   addSplit: '添加拆分',

--- a/pdf_wizard/frontend/wailsjs/go/main/App.d.ts
+++ b/pdf_wizard/frontend/wailsjs/go/main/App.d.ts
@@ -20,13 +20,13 @@ export function MergePDFs(arg1:Array<string>,arg2:string,arg3:string):Promise<vo
 
 export function RotatePDF(arg1:string,arg2:Array<models.RotateDefinition>,arg3:string,arg4:string):Promise<void>;
 
-export function SelectImageFiles():Promise<Array<string>>;
+export function SelectImageFiles(arg1:models.FileDialogLabels):Promise<Array<string>>;
 
-export function SelectOutputDirectory():Promise<string>;
+export function SelectOutputDirectory(arg1:models.FileDialogLabels):Promise<string>;
 
-export function SelectPDFFile():Promise<string>;
+export function SelectPDFFile(arg1:models.FileDialogLabels):Promise<string>;
 
-export function SelectPDFFiles():Promise<Array<string>>;
+export function SelectPDFFiles(arg1:models.FileDialogLabels):Promise<Array<string>>;
 
 export function SetLanguage(arg1:string):Promise<void>;
 

--- a/pdf_wizard/frontend/wailsjs/go/main/App.js
+++ b/pdf_wizard/frontend/wailsjs/go/main/App.js
@@ -38,20 +38,20 @@ export function RotatePDF(arg1, arg2, arg3, arg4) {
   return window['go']['main']['App']['RotatePDF'](arg1, arg2, arg3, arg4);
 }
 
-export function SelectImageFiles() {
-  return window['go']['main']['App']['SelectImageFiles']();
+export function SelectImageFiles(arg1) {
+  return window['go']['main']['App']['SelectImageFiles'](arg1);
 }
 
-export function SelectOutputDirectory() {
-  return window['go']['main']['App']['SelectOutputDirectory']();
+export function SelectOutputDirectory(arg1) {
+  return window['go']['main']['App']['SelectOutputDirectory'](arg1);
 }
 
-export function SelectPDFFile() {
-  return window['go']['main']['App']['SelectPDFFile']();
+export function SelectPDFFile(arg1) {
+  return window['go']['main']['App']['SelectPDFFile'](arg1);
 }
 
-export function SelectPDFFiles() {
-  return window['go']['main']['App']['SelectPDFFiles']();
+export function SelectPDFFiles(arg1) {
+  return window['go']['main']['App']['SelectPDFFiles'](arg1);
 }
 
 export function SetLanguage(arg1) {

--- a/pdf_wizard/frontend/wailsjs/go/models.ts
+++ b/pdf_wizard/frontend/wailsjs/go/models.ts
@@ -1,5 +1,19 @@
 export namespace models {
 	
+	export class FileDialogLabels {
+	    title: string;
+	    filterDisplayName: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new FileDialogLabels(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.title = source["title"];
+	        this.filterDisplayName = source["filterDisplayName"];
+	    }
+	}
 	export class PDFMetadata {
 	    path: string;
 	    name: string;

--- a/pdf_wizard/models/types.go
+++ b/pdf_wizard/models/types.go
@@ -1,5 +1,12 @@
 package models
 
+// FileDialogLabels carries user-visible strings for native file/folder dialogs.
+// The frontend sets these from i18n; empty fields fall back to English defaults in FileService.
+type FileDialogLabels struct {
+	Title             string `json:"title"`
+	FilterDisplayName string `json:"filterDisplayName"` // file pickers only; optional
+}
+
 // PDFMetadata represents file information including PDF metadata
 type PDFMetadata struct {
 	Path         string `json:"path"`

--- a/pdf_wizard/services/DESIGN.md
+++ b/pdf_wizard/services/DESIGN.md
@@ -55,35 +55,35 @@ func NewFileService(ctx context.Context) *FileService {
 
 ### Methods
 
-#### `SelectPDFFiles() ([]string, error)`
+#### `SelectPDFFiles(labels models.FileDialogLabels) ([]string, error)`
 
 Opens a native file dialog to select multiple PDF files.
 
-- Uses `runtime.OpenMultipleFilesDialog()` with PDF filter
+- Uses `runtime.OpenMultipleFilesDialog()` with PDF filter; dialog title and filter display name come from `labels` (empty strings fall back to English defaults)
 - Returns array of selected file paths
 - Returns error if dialog is cancelled or fails
 
-#### `SelectPDFFile() (string, error)`
+#### `SelectPDFFile(labels models.FileDialogLabels) (string, error)`
 
 Opens a native file dialog to select a single PDF file.
 
-- Uses `runtime.OpenFileDialog()` with PDF filter
+- Uses `runtime.OpenFileDialog()` with PDF filter; `labels` supplies localized title and filter label (empty → English defaults)
 - Returns selected file path
 - Returns error if no file selected or dialog fails
 
-#### `SelectImageFiles() ([]string, error)`
+#### `SelectImageFiles(labels models.FileDialogLabels) ([]string, error)`
 
 Opens a native file dialog to select multiple image files.
 
-- Uses `runtime.OpenMultipleFilesDialog()` with an image filter (JPEG, PNG, WebP, TIFF, GIF, BMP, HEIC, HEIF)
+- Uses `runtime.OpenMultipleFilesDialog()` with an image filter (JPEG, PNG, WebP, TIFF, GIF, BMP, HEIC, HEIF); `labels` for title and filter display name
 - Returns array of selected paths
 - Returns error if dialog is cancelled or fails
 
-#### `SelectOutputDirectory() (string, error)`
+#### `SelectOutputDirectory(labels models.FileDialogLabels) (string, error)`
 
 Opens a native directory dialog to select an output directory.
 
-- Uses `runtime.OpenDirectoryDialog()`
+- Uses `runtime.OpenDirectoryDialog()`; `labels.Title` is the dialog title (`filterDisplayName` is unused for directories)
 - Returns selected directory path
 - Returns error if dialog is cancelled or fails
 

--- a/pdf_wizard/services/file_service.go
+++ b/pdf_wizard/services/file_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pdfcpu/pdfcpu/pkg/api"
@@ -12,6 +13,20 @@ import (
 
 	"pdf_wizard/models"
 )
+
+func dialogTitle(primary, fallback string) string {
+	if strings.TrimSpace(primary) != "" {
+		return primary
+	}
+	return fallback
+}
+
+func filterDisplayName(primary, fallback string) string {
+	if strings.TrimSpace(primary) != "" {
+		return primary
+	}
+	return fallback
+}
 
 // FileService handles file operations and dialogs
 type FileService struct {
@@ -24,12 +39,12 @@ func NewFileService(ctx context.Context) *FileService {
 }
 
 // SelectPDFFiles opens a file dialog to select multiple PDF files
-func (s *FileService) SelectPDFFiles() ([]string, error) {
+func (s *FileService) SelectPDFFiles(labels models.FileDialogLabels) ([]string, error) {
 	selection, err := runtime.OpenMultipleFilesDialog(s.ctx, runtime.OpenDialogOptions{
-		Title: "Select PDF Files",
+		Title: dialogTitle(labels.Title, "Select PDF Files"),
 		Filters: []runtime.FileFilter{
 			{
-				DisplayName: "PDF files",
+				DisplayName: filterDisplayName(labels.FilterDisplayName, "PDF files"),
 				Pattern:     "*.pdf",
 			},
 		},
@@ -41,12 +56,12 @@ func (s *FileService) SelectPDFFiles() ([]string, error) {
 }
 
 // SelectImageFiles opens a file dialog to select multiple image files.
-func (s *FileService) SelectImageFiles() ([]string, error) {
+func (s *FileService) SelectImageFiles(labels models.FileDialogLabels) ([]string, error) {
 	selection, err := runtime.OpenMultipleFilesDialog(s.ctx, runtime.OpenDialogOptions{
-		Title: "Select Image Files",
+		Title: dialogTitle(labels.Title, "Select Image Files"),
 		Filters: []runtime.FileFilter{
 			{
-				DisplayName: "Images",
+				DisplayName: filterDisplayName(labels.FilterDisplayName, "Images"),
 				Pattern:     "*.jpg;*.jpeg;*.png;*.gif;*.webp;*.tif;*.tiff;*.bmp;*.heic;*.heif;*.HEIC;*.HEIF",
 			},
 		},
@@ -58,12 +73,12 @@ func (s *FileService) SelectImageFiles() ([]string, error) {
 }
 
 // SelectPDFFile opens a file dialog to select a single PDF file
-func (s *FileService) SelectPDFFile() (string, error) {
+func (s *FileService) SelectPDFFile(labels models.FileDialogLabels) (string, error) {
 	selection, err := runtime.OpenFileDialog(s.ctx, runtime.OpenDialogOptions{
-		Title: "Select PDF File",
+		Title: dialogTitle(labels.Title, "Select PDF File"),
 		Filters: []runtime.FileFilter{
 			{
-				DisplayName: "PDF files",
+				DisplayName: filterDisplayName(labels.FilterDisplayName, "PDF files"),
 				Pattern:     "*.pdf",
 			},
 		},
@@ -78,9 +93,9 @@ func (s *FileService) SelectPDFFile() (string, error) {
 }
 
 // SelectOutputDirectory opens a directory dialog to select output directory
-func (s *FileService) SelectOutputDirectory() (string, error) {
+func (s *FileService) SelectOutputDirectory(labels models.FileDialogLabels) (string, error) {
 	selection, err := runtime.OpenDirectoryDialog(s.ctx, runtime.OpenDialogOptions{
-		Title: "Select Output Directory",
+		Title: dialogTitle(labels.Title, "Select Output Directory"),
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Summary
Native Wails file and folder dialogs now receive localized titles and (where applicable) filter display names from the active UI language via `models.FileDialogLabels` passed from the frontend through `App` to `FileService`.

## Changes
- Added `FileDialogLabels` (title + filter display name) in Go models; `FileService` and `App` methods `SelectPDFFiles`, `SelectPDFFile`, `SelectImageFiles`, `SelectOutputDirectory` accept labels with English fallbacks when strings are empty.
- Frontend tabs and `useOutputDirectory` pass `t(...)` strings; new i18n keys for PDF/image filter labels.
- E2E mocks accept the new first argument.
- Refreshed macOS distributables under `pdf_wizard/dist/` via `build-dist.sh`.
- Updated `pdf_wizard/DESIGN.md` and `pdf_wizard/services/DESIGN.md`.

## Testing
- `go test ./...` (from `pdf_wizard/`)
- `npm run build` and `npm run test:e2e` (from `pdf_wizard/frontend/`)
- `bash pdf_wizard/build-dist.sh`

Closes #86

Made with [Cursor](https://cursor.com)