### PR TITLE
[PDF-109] Sanitize output filenames to prevent path traversal

### DIFF
--- a/pdf_wizard/services/DESIGN.md
+++ b/pdf_wizard/services/DESIGN.md
@@ -285,6 +285,7 @@ Shared helpers used by services:
 - **`validatePDFFile` / `isPDFFile`** — PDF inputs
 - **`validateImageFile` / `isImageFile`** — Raster inputs for `ImagesToPDF` (including `.heic` / `.heif`)
 - **`validateOutputDirectory`** — Output directory exists and is writable
+- **`sanitizeOutputBasename` / `resolveOutputPDFPath`** — Output basenames must be a single safe segment (no `/`, `\`, `.`, `..`); joined paths are checked so writes cannot escape the chosen output directory (#109)
 
 ## Data Models
 

--- a/pdf_wizard/services/pdf_service.go
+++ b/pdf_wizard/services/pdf_service.go
@@ -51,9 +51,10 @@ func (s *PDFService) MergePDFs(inputPaths []string, outputDirectory string, outp
 		return err
 	}
 
-	// outputFilename from frontend does not include .pdf extension
-	// Always append .pdf extension
-	outputPath := filepath.Join(outputDirectory, outputFilename+PDFExtension)
+	outputPath, err := resolveOutputPDFPath(outputDirectory, outputFilename)
+	if err != nil {
+		return err
+	}
 
 	// Remove existing output file if it exists (pdfcpu may have issues overwriting)
 	if err := removeIfExists(outputPath); err != nil {
@@ -63,7 +64,7 @@ func (s *PDFService) MergePDFs(inputPaths []string, outputDirectory string, outp
 	// Merge first: MergeCreateFile reads every input once. A separate ReadContextFile
 	// pass per input would double I/O and parse work on success paths (#53).
 	config := model.NewDefaultConfiguration()
-	err := api.MergeCreateFile(inputPaths, outputPath, false, config)
+	err = api.MergeCreateFile(inputPaths, outputPath, false, config)
 	if err != nil {
 		// If merge failed, try per-input read to pinpoint a broken file (same UX as before).
 		if diagErr := mergeDiagnoseInputs(inputPaths); diagErr != nil {
@@ -99,11 +100,10 @@ func (s *PDFService) ImagesToPDF(imagePaths []string, outputDirectory string, ou
 	if err := validateOutputDirectory(outputDirectory); err != nil {
 		return err
 	}
-	if strings.TrimSpace(outputFilename) == "" {
-		return fmt.Errorf("output filename cannot be empty")
+	outputPath, err := resolveOutputPDFPath(outputDirectory, outputFilename)
+	if err != nil {
+		return err
 	}
-
-	outputPath := filepath.Join(outputDirectory, strings.TrimSpace(outputFilename)+PDFExtension)
 	if err := removeIfExists(outputPath); err != nil {
 		return err
 	}
@@ -138,11 +138,10 @@ func (s *PDFService) LockPDF(inputPath string, password string, outputDirectory 
 	if err := validateOutputDirectory(outputDirectory); err != nil {
 		return err
 	}
-	if strings.TrimSpace(outputFilename) == "" {
-		return fmt.Errorf("output filename cannot be empty")
+	outputPath, err := resolveOutputPDFPath(outputDirectory, outputFilename)
+	if err != nil {
+		return err
 	}
-
-	outputPath := filepath.Join(outputDirectory, strings.TrimSpace(outputFilename)+PDFExtension)
 	if err := removeIfExists(outputPath); err != nil {
 		return err
 	}
@@ -169,11 +168,10 @@ func (s *PDFService) UnlockPDF(inputPath string, password string, outputDirector
 	if err := validateOutputDirectory(outputDirectory); err != nil {
 		return err
 	}
-	if strings.TrimSpace(outputFilename) == "" {
-		return fmt.Errorf("output filename cannot be empty")
+	outputPath, err := resolveOutputPDFPath(outputDirectory, outputFilename)
+	if err != nil {
+		return err
 	}
-
-	outputPath := filepath.Join(outputDirectory, strings.TrimSpace(outputFilename)+PDFExtension)
 	if err := removeIfExists(outputPath); err != nil {
 		return err
 	}
@@ -227,15 +225,19 @@ func (s *PDFService) SplitPDF(inputPath string, splits []models.SplitDefinition,
 		if split.EndPage < split.StartPage || split.EndPage > totalPages {
 			return fmt.Errorf("split %d: end page %d is invalid (must be >= start page and <= %d)", i+1, split.EndPage, totalPages)
 		}
-		if strings.TrimSpace(split.Filename) == "" {
-			return fmt.Errorf("split %d: filename cannot be empty", i+1)
+		if _, err := sanitizeOutputBasename(split.Filename); err != nil {
+			return fmt.Errorf("split %d: %w", i+1, err)
 		}
 	}
 
-	// Check for duplicate filenames
+	// Check for duplicate filenames (after sanitization)
 	filenameMap := make(map[string]bool)
-	for _, split := range splits {
-		filename := strings.TrimSpace(split.Filename) + PDFExtension
+	for i, split := range splits {
+		safeName, err := sanitizeOutputBasename(split.Filename)
+		if err != nil {
+			return fmt.Errorf("split %d: %w", i+1, err)
+		}
+		filename := safeName + PDFExtension
 		if filenameMap[filename] {
 			return fmt.Errorf("duplicate filename: %s", filename)
 		}
@@ -244,7 +246,10 @@ func (s *PDFService) SplitPDF(inputPath string, splits []models.SplitDefinition,
 
 	// Process each split: extract from the shared in-memory context (same as api.Trim).
 	for i, split := range splits {
-		outputPath := filepath.Join(outputDirectory, strings.TrimSpace(split.Filename)+PDFExtension)
+		outputPath, err := resolveOutputPDFPath(outputDirectory, split.Filename)
+		if err != nil {
+			return fmt.Errorf("split %d: %w", i+1, err)
+		}
 
 		if err := removeIfExists(outputPath); err != nil {
 			return err
@@ -308,11 +313,6 @@ func (s *PDFService) RotatePDF(inputPath string, rotations []models.RotateDefini
 		return err
 	}
 
-	// Validate output filename
-	if strings.TrimSpace(outputFilename) == "" {
-		return fmt.Errorf("output filename cannot be empty")
-	}
-
 	// Get PDF page count for validation
 	totalPages, err := s.fileService.GetPDFPageCount(inputPath)
 	if err != nil {
@@ -333,9 +333,10 @@ func (s *PDFService) RotatePDF(inputPath string, rotations []models.RotateDefini
 		}
 	}
 
-	// outputFilename from frontend does not include .pdf extension
-	// Always append .pdf extension
-	outputPath := filepath.Join(outputDirectory, outputFilename+PDFExtension)
+	outputPath, err := resolveOutputPDFPath(outputDirectory, outputFilename)
+	if err != nil {
+		return err
+	}
 
 	// Create a temporary copy of the input file for rotation operations
 	// pdfcpu RotatePages modifies the file in place, so we need to work with a copy
@@ -391,11 +392,6 @@ func (s *PDFService) ApplyWatermark(inputPath string, watermark models.Watermark
 		return err
 	}
 
-	// Validate output filename
-	if strings.TrimSpace(outputFilename) == "" {
-		return fmt.Errorf("output filename cannot be empty")
-	}
-
 	// Validate text watermark configuration
 	if strings.TrimSpace(watermark.TextConfig.Text) == "" {
 		return fmt.Errorf("watermark text cannot be empty")
@@ -426,9 +422,10 @@ func (s *PDFService) ApplyWatermark(inputPath string, watermark models.Watermark
 		}
 	}
 
-	// outputFilename from frontend does not include .pdf extension
-	// Always append .pdf extension
-	outputPath := filepath.Join(outputDirectory, outputFilename+PDFExtension)
+	outputPath, err := resolveOutputPDFPath(outputDirectory, outputFilename)
+	if err != nil {
+		return err
+	}
 
 	// Create a temporary copy of the input file for watermark operations
 	tempPath := outputPath + ".tmp"

--- a/pdf_wizard/services/pdf_service_test.go
+++ b/pdf_wizard/services/pdf_service_test.go
@@ -72,6 +72,25 @@ func TestPDFService_MergePDFs(t *testing.T) {
 	}
 }
 
+func TestPDFService_MergePDFs_rejectsUnsafeOutputFilename(t *testing.T) {
+	testDir := t.TempDir()
+	pdf1 := filepath.Join(testDir, "a.pdf")
+	if err := createTestPDF(pdf1); err != nil {
+		t.Fatalf("createTestPDF: %v", err)
+	}
+
+	fileService := NewFileService(context.Background())
+	service := NewPDFService(fileService)
+
+	err := service.MergePDFs([]string{pdf1}, testDir, "../escape")
+	if err == nil {
+		t.Fatal("expected error for unsafe output filename")
+	}
+	if !strings.Contains(err.Error(), "path separators") && !strings.Contains(err.Error(), "invalid output filename") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestPDFService_MergePDFs_InvalidInputDiagnosed(t *testing.T) {
 	fileService := NewFileService(context.Background())
 	service := NewPDFService(fileService)

--- a/pdf_wizard/services/validation.go
+++ b/pdf_wizard/services/validation.go
@@ -94,3 +94,52 @@ func validateOutputDirectory(path string) error {
 	return nil
 }
 
+// sanitizeOutputBasename returns a single path segment safe for use as an output
+// filename (without extension). Rejects empty names, ".", "..", and separators.
+func sanitizeOutputBasename(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", fmt.Errorf("output filename cannot be empty")
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return "", fmt.Errorf("output filename must not contain path separators")
+	}
+	base := filepath.Base(name)
+	if base == "." || base == ".." {
+		return "", fmt.Errorf("invalid output filename: %s", base)
+	}
+	if base != name {
+		return "", fmt.Errorf("invalid output filename: %s", name)
+	}
+	return base, nil
+}
+
+// resolveOutputPDFPath joins outputDirectory with a sanitized basename and PDFExtension,
+// ensuring the result does not escape outputDirectory (#109).
+func resolveOutputPDFPath(outputDirectory, outputFilename string) (string, error) {
+	base, err := sanitizeOutputBasename(outputFilename)
+	if err != nil {
+		return "", err
+	}
+
+	outPath := filepath.Join(outputDirectory, base+PDFExtension)
+
+	absDir, err := filepath.Abs(filepath.Clean(outputDirectory))
+	if err != nil {
+		return "", fmt.Errorf("invalid output directory: %w", err)
+	}
+	absOut, err := filepath.Abs(filepath.Clean(outPath))
+	if err != nil {
+		return "", fmt.Errorf("invalid output path: %w", err)
+	}
+
+	rel, err := filepath.Rel(absDir, absOut)
+	if err != nil {
+		return "", fmt.Errorf("output path is outside output directory")
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("output path escapes output directory")
+	}
+
+	return outPath, nil
+}

--- a/pdf_wizard/services/validation_test.go
+++ b/pdf_wizard/services/validation_test.go
@@ -1,0 +1,85 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeOutputBasename(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "simple", input: "merged", want: "merged"},
+		{name: "trim space", input: "  report  ", want: "report"},
+		{name: "empty", input: "", wantErr: true},
+		{name: "whitespace only", input: "   ", wantErr: true},
+		{name: "dot", input: ".", wantErr: true},
+		{name: "dotdot", input: "..", wantErr: true},
+		{name: "unix traversal", input: "../../etc/passwd", wantErr: true},
+		{name: "unix subpath", input: "foo/bar", wantErr: true},
+		{name: "backslash", input: "foo\\bar", wantErr: true},
+		{name: "leading dot segment", input: "./out", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := sanitizeOutputBasename(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("sanitizeOutputBasename(%q) expected error", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("sanitizeOutputBasename(%q): %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveOutputPDFPath_staysInDirectory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "out")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := resolveOutputPDFPath(sub, "report")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(sub, "report"+PDFExtension)
+	if out != want {
+		t.Fatalf("got %q, want %q", out, want)
+	}
+
+	absDir, _ := filepath.Abs(sub)
+	absOut, _ := filepath.Abs(out)
+	if !strings.HasPrefix(absOut, absDir+string(filepath.Separator)) {
+		t.Fatalf("output %q not under %q", absOut, absDir)
+	}
+}
+
+func TestResolveOutputPDFPath_rejectsUnsafeNames(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, err := resolveOutputPDFPath(dir, "../escape")
+	if err == nil {
+		t.Fatal("expected error for path traversal basename")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds **`sanitizeOutputBasename`** to reject empty names, `.`, `..`, and any `/` or `\` in output basenames.
- Adds **`resolveOutputPDFPath`** to join `outputDirectory` + basename + `.pdf` and verify the resolved path cannot escape the output directory (via `filepath.Rel`).
- Wires all PDF write paths in **`pdf_service.go`**: merge, split (per segment), rotate, watermark, images→PDF, lock, and unlock.

## Tests

- [x] `validation_test.go` — basename cases and directory containment
- [x] `TestPDFService_MergePDFs_rejectsUnsafeOutputFilename` — integration guard for `../escape`
- [x] `go test ./...` from `pdf_wizard/`

Closes #109

Made with [Cursor](https://cursor.com)