### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+PDF Wizard is a **Wails v2 desktop app** (Go backend + React/TypeScript frontend in an embedded WebView). It cannot be fully launched with `wails dev` in headless cloud environments since Wails requires a native window/WebView. For development and testing, the **frontend** runs independently via Vite and the **Go backend** is tested via `go test`.
+
+### Environment
+
+- **Go 1.25** installed at `/usr/local/go`. Ensure `PATH` includes `/usr/local/go/bin:$HOME/go/bin`.
+- **Node.js 22.21.1** managed by nvm (default alias set). Source nvm before running npm commands:
+  ```
+  export NVM_DIR="$HOME/.nvm"; [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+  ```
+- **Wails CLI v2.12.0** at `$HOME/go/bin/wails`.
+
+### Key commands (see `pdf_wizard/README.md` for full reference)
+
+| Task | Command | Working directory |
+|------|---------|-------------------|
+| Go tests | `go test -v ./...` | `pdf_wizard/` |
+| Go lint | `go vet ./...` | `pdf_wizard/` |
+| Frontend build (required before Go tests due to `go:embed`) | `npm run build` | `pdf_wizard/frontend/` |
+| TypeScript type-check | `npx tsc --noEmit` | `pdf_wizard/frontend/` |
+| E2E tests (auto-starts Vite) | `npm run test:e2e` | `pdf_wizard/frontend/` |
+| Vite dev server (standalone frontend) | `npm run dev` | `pdf_wizard/frontend/` |
+| Install Playwright browsers | `npx playwright install --with-deps chromium` | `pdf_wizard/frontend/` |
+
+### Gotchas
+
+- **Frontend `dist/` must exist before running Go tests.** `main.go` uses `go:embed frontend/dist` — if `dist/` is missing, `go build` and `go test` will fail. Always run `npm run build` in `pdf_wizard/frontend/` first.
+- **Playwright E2E tests auto-start Vite** via `webServer` config in `playwright.config.ts`. No need to start the dev server manually before running `npm run test:e2e`.
+- **`wails dev` requires a display/WebView** and will fail in headless environments. Use the Vite dev server directly (`npm run dev`) for frontend development and Playwright for UI testing.
+- **No external services required.** No database, Docker, or external APIs — everything is local/in-process.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,34 +2,11 @@
 
 ## Cursor Cloud specific instructions
 
-### Overview
+For commands, stack versions, and project structure see [README.md](README.md) and [pdf_wizard/README.md](pdf_wizard/README.md).
 
-PDF Wizard is a **Wails v2 desktop app** (Go backend + React/TypeScript frontend in an embedded WebView). It cannot be fully launched with `wails dev` in headless cloud environments since Wails requires a native window/WebView. For development and testing, the **frontend** runs independently via Vite and the **Go backend** is tested via `go test`.
+### Cloud-specific gotchas
 
-### Environment
-
-- **Go 1.25** installed at `/usr/local/go`. Ensure `PATH` includes `/usr/local/go/bin:$HOME/go/bin`.
-- **Node.js 22.21.1** managed by nvm (default alias set). Source nvm before running npm commands:
-  ```
-  export NVM_DIR="$HOME/.nvm"; [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-  ```
-- **Wails CLI v2.12.0** at `$HOME/go/bin/wails`.
-
-### Key commands (see `pdf_wizard/README.md` for full reference)
-
-| Task | Command | Working directory |
-|------|---------|-------------------|
-| Go tests | `go test -v ./...` | `pdf_wizard/` |
-| Go lint | `go vet ./...` | `pdf_wizard/` |
-| Frontend build (required before Go tests due to `go:embed`) | `npm run build` | `pdf_wizard/frontend/` |
-| TypeScript type-check | `npx tsc --noEmit` | `pdf_wizard/frontend/` |
-| E2E tests (auto-starts Vite) | `npm run test:e2e` | `pdf_wizard/frontend/` |
-| Vite dev server (standalone frontend) | `npm run dev` | `pdf_wizard/frontend/` |
-| Install Playwright browsers | `npx playwright install --with-deps chromium` | `pdf_wizard/frontend/` |
-
-### Gotchas
-
-- **Frontend `dist/` must exist before running Go tests.** `main.go` uses `go:embed frontend/dist` — if `dist/` is missing, `go build` and `go test` will fail. Always run `npm run build` in `pdf_wizard/frontend/` first.
-- **Playwright E2E tests auto-start Vite** via `webServer` config in `playwright.config.ts`. No need to start the dev server manually before running `npm run test:e2e`.
-- **`wails dev` requires a display/WebView** and will fail in headless environments. Use the Vite dev server directly (`npm run dev`) for frontend development and Playwright for UI testing.
-- **No external services required.** No database, Docker, or external APIs — everything is local/in-process.
+- **`wails dev` won't work** — it requires a native WebView/display. Use `npm run dev` (Vite) for frontend work and Playwright for UI testing.
+- **Frontend `dist/` must exist before `go test`** — `main.go` uses `go:embed frontend/dist`. Run `npm run build` in `pdf_wizard/frontend/` first.
+- **nvm must be sourced** before npm/node commands: `export NVM_DIR="$HOME/.nvm"; [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"`
+- **Go lives at `/usr/local/go/bin`** — ensure PATH includes it and `$HOME/go/bin` (for Wails CLI).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a minimal `AGENTS.md` that references existing repo documentation and only captures cloud-specific gotchas that aren't documented elsewhere.

### What's included

- Link to `README.md` and `pdf_wizard/README.md` for commands/stack/structure
- Four non-obvious cloud-environment gotchas:
  - `wails dev` requires a display (use Vite + Playwright instead)
  - `frontend/dist/` must be built before Go tests (`go:embed`)
  - nvm must be sourced before npm/node commands
  - Go/Wails PATH setup
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4da351e0-1e71-4480-88ae-a95a7b57d1d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4da351e0-1e71-4480-88ae-a95a7b57d1d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

