### PR TITLE
[PDF-114] Consolidate language bootstrap in usePersistedLanguage

### DIFF
--- a/pdf_wizard/frontend/src/App.tsx
+++ b/pdf_wizard/frontend/src/App.tsx
@@ -4,9 +4,8 @@ import { Box, Tabs, Tab, AppBar, Toolbar, Typography, CircularProgress } from '@
 import { SettingsDialog } from './components/SettingsDialog';
 import logo from './assets/img/app_logo.png';
 import { OnFileDrop, OnFileDropOff, EventsOn } from '../wailsjs/runtime/runtime';
-import { GetLanguage } from '../wailsjs/go/main/App';
-import { useI18n, type Language } from './utils/i18n';
-import { isValidLanguage } from './utils/i18n/constants';
+import { useI18n } from './utils/i18n';
+import { usePersistedLanguage } from './hooks/usePersistedLanguage';
 import { MAIN_TAB_IDS, type MainTabId } from './utils/constants';
 
 const TAB_LABEL_KEY: Record<
@@ -76,27 +75,13 @@ const TAB_COMPONENT: Record<MainTabId, React.LazyExoticComponent<React.Component
 };
 
 export const App = () => {
-  const { t, setLanguage, language } = useI18n();
+  const { t } = useI18n();
+  const { language } = usePersistedLanguage();
   const [tabId, setTabId] = useState<MainTabId>('merge');
   const [visitedTabs, setVisitedTabs] = useState<Set<MainTabId>>(() => new Set<MainTabId>(['merge']));
   const [settingsOpen, setSettingsOpen] = useState(false);
   const activeTabIdRef = useRef<MainTabId>('merge');
   const dropHandlersRef = useRef<Partial<Record<MainTabId, (paths: string[]) => void>>>({});
-
-  // Load language on startup
-  useEffect(() => {
-    const loadLanguage = async () => {
-      try {
-        const lang = await GetLanguage();
-        // Validate language code and default to 'en' if invalid
-        const language = (isValidLanguage(lang) ? lang : 'en') as Language;
-        setLanguage(language);
-      } catch (err) {
-        console.error('Failed to load language:', err);
-      }
-    };
-    loadLanguage();
-  }, []);
 
   // Listen for settings event from menu
   useEffect(() => {

--- a/pdf_wizard/frontend/src/components/SettingsDialog.tsx
+++ b/pdf_wizard/frontend/src/components/SettingsDialog.tsx
@@ -12,9 +12,9 @@ import {
   Box,
   SelectChangeEvent,
 } from '@mui/material';
-import { GetLanguage, SetLanguage } from '../../wailsjs/go/main/App';
 import { useI18n, getNativeLanguageName, type Language } from '../utils/i18n';
-import { SUPPORTED_LANGUAGES, isValidLanguage } from '../utils/i18n/constants';
+import { SUPPORTED_LANGUAGES } from '../utils/i18n/constants';
+import { usePersistedLanguage } from '../hooks/usePersistedLanguage';
 
 interface SettingsDialogProps {
   open: boolean;
@@ -22,27 +22,16 @@ interface SettingsDialogProps {
 }
 
 export const SettingsDialog = ({ open, onClose }: SettingsDialogProps) => {
-  const { t, setLanguage } = useI18n();
-  const [selectedLanguage, setSelectedLanguage] = useState<Language>('en');
+  const { t } = useI18n();
+  const { language, saveLanguage } = usePersistedLanguage();
+  const [selectedLanguage, setSelectedLanguage] = useState<Language>(language);
   const [loading, setLoading] = useState(false);
 
-  // Load current language setting when dialog opens
   useEffect(() => {
     if (open) {
-      loadLanguage();
-    }
-  }, [open]);
-
-  const loadLanguage = async () => {
-    try {
-      const lang = await GetLanguage();
-      // Validate language code and default to 'en' if invalid
-      const language = (isValidLanguage(lang) ? lang : 'en') as Language;
       setSelectedLanguage(language);
-    } catch (err) {
-      console.error('Failed to load language:', err);
     }
-  };
+  }, [open, language]);
 
   const handleLanguageChange = (event: SelectChangeEvent<string>) => {
     const newLanguage = event.target.value as Language;
@@ -52,8 +41,7 @@ export const SettingsDialog = ({ open, onClose }: SettingsDialogProps) => {
   const handleSave = async () => {
     setLoading(true);
     try {
-      await SetLanguage(selectedLanguage);
-      setLanguage(selectedLanguage);
+      await saveLanguage(selectedLanguage);
       onClose();
     } catch (err) {
       console.error('Failed to save language:', err);
@@ -63,8 +51,7 @@ export const SettingsDialog = ({ open, onClose }: SettingsDialogProps) => {
   };
 
   const handleCancel = () => {
-    // Reset to current language
-    loadLanguage();
+    setSelectedLanguage(language);
     onClose();
   };
 

--- a/pdf_wizard/frontend/src/hooks/usePersistedLanguage.ts
+++ b/pdf_wizard/frontend/src/hooks/usePersistedLanguage.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect, useCallback } from 'react';
+import { GetLanguage, SetLanguage } from '../../wailsjs/go/main/App';
+import { useI18n, type Language } from '../utils/i18n';
+import { isValidLanguage } from '../utils/i18n/constants';
+import { getErrorMessage } from '../utils/errors';
+
+/**
+ * Hook that owns the persisted language lifecycle:
+ * loads from the Go backend on mount, validates, and exposes
+ * a saveLanguage helper that persists to backend + updates i18n context.
+ */
+export function usePersistedLanguage() {
+  const { setLanguage, language } = useI18n();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const lang = await GetLanguage();
+        const validated: Language = isValidLanguage(lang) ? lang : 'en';
+        setLanguage(validated);
+      } catch (err) {
+        console.error('Failed to load language:', getErrorMessage(err));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    load();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const saveLanguage = useCallback(
+    async (lang: Language) => {
+      await SetLanguage(lang);
+      setLanguage(lang);
+    },
+    [setLanguage],
+  );
+
+  return { language, saveLanguage, isLoading };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Creates a single `usePersistedLanguage` hook that owns `GetLanguage`, `SetLanguage`, and `setLanguage` lifecycle, replacing duplicate logic in `App.tsx` and `SettingsDialog.tsx`.

### Changes
- Created `pdf_wizard/frontend/src/hooks/usePersistedLanguage.ts`:
  - Loads persisted language on mount via `GetLanguage()`
  - Validates with `isValidLanguage`, defaults to 'en'
  - Exposes `saveLanguage(lang)` that persists to Go backend AND updates i18n context
  - Returns `{ language, saveLanguage, isLoading }`
- Updated `App.tsx` — removed inline useEffect, uses `usePersistedLanguage()`
- Updated `SettingsDialog.tsx` — removed duplicate loadLanguage/SetLanguage, uses `usePersistedLanguage()`

### Testing
- ✅ `npx tsc --noEmit` — compiles cleanly
- ✅ `npm run build` — production build succeeds
- ✅ `npm run test:e2e` — all 36 tests pass (including 7 i18n-specific tests)

Closes #114
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4da351e0-1e71-4480-88ae-a95a7b57d1d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4da351e0-1e71-4480-88ae-a95a7b57d1d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

